### PR TITLE
Scrypt iteration 3

### DIFF
--- a/src/main/java/convex/core/lang/AbstractScryptCharacterMatcher.java
+++ b/src/main/java/convex/core/lang/AbstractScryptCharacterMatcher.java
@@ -1,0 +1,42 @@
+package convex.core.lang;
+
+import org.parboiled.MatcherContext;
+import org.parboiled.matchers.CustomMatcher;
+
+public abstract class AbstractScryptCharacterMatcher extends CustomMatcher {
+
+    protected AbstractScryptCharacterMatcher(String label) {
+        super(label);
+    }
+
+    @Override
+    public final boolean isSingleCharMatcher() {
+        return true;
+    }
+
+    @Override
+    public final boolean canMatchEmpty() {
+        return false;
+    }
+
+    @Override
+    public boolean isStarterChar(char c) {
+        return acceptChar(c);
+    }
+
+    @Override
+    public final char getStarterChar() {
+        return 'a';
+    }
+
+    public final <V> boolean match(MatcherContext<V> context) {
+        if (!acceptChar(context.getCurrentChar())) {
+            return false;
+        }
+        context.advanceIndex(1);
+        context.createNode();
+        return true;
+    }
+
+    protected abstract boolean acceptChar(char c);
+}

--- a/src/main/java/convex/core/lang/Scrypt2.java
+++ b/src/main/java/convex/core/lang/Scrypt2.java
@@ -1,0 +1,514 @@
+package convex.core.lang;
+
+import convex.core.data.*;
+import org.parboiled.Parboiled;
+import org.parboiled.Rule;
+import org.parboiled.annotations.BuildParseTree;
+import org.parboiled.annotations.DontLabel;
+import org.parboiled.annotations.MemoMismatches;
+import org.parboiled.annotations.SuppressNode;
+import org.parboiled.parserunners.ReportingParseRunner;
+import org.parboiled.support.Var;
+
+import java.util.ArrayList;
+
+@BuildParseTree
+public class Scrypt2 extends Reader {
+
+    // Use a ThreadLocal reader because instances are not thread safe
+    private static final ThreadLocal<Scrypt2> syntaxReader = ThreadLocal.withInitial(() -> Parboiled.createParser(Scrypt2.class));
+    public final Rule FN = Keyword("fn");
+    public final Rule IF = Keyword("if");
+    public final Rule ELSE = Keyword("else");
+
+    final Rule EQU = Terminal("=", Ch('='));
+    final Rule COMMA = Terminal(",");
+    final Rule LPAR = Terminal("(");
+    final Rule RPAR = Terminal(")");
+    final Rule LWING = Terminal("{");
+    final Rule RWING = Terminal("}");
+    final Rule SEMI = Terminal(";");
+
+    /**
+     * Constructor for reader class. Called by Parboiled.createParser
+     */
+    public Scrypt2() {
+        super(true);
+    }
+
+    /**
+     * Parses an expression and returns a Syntax object
+     *
+     * @param source
+     * @return Parsed form
+     */
+    @SuppressWarnings("rawtypes")
+    public static Syntax readSyntax(String source) {
+        Scrypt2 scryptReader = syntaxReader.get();
+        scryptReader.tempSource = source;
+
+        var rule = scryptReader.CompilationUnit();
+        var result = new ReportingParseRunner(rule).run(source);
+
+        if (result.matched) {
+            return (Syntax) result.resultValue;
+        } else {
+            throw new RuntimeException(rule.toString() + " failed to match " + source);
+        }
+    }
+
+    // --------------------------------
+    // COMPILATION UNIT
+    // --------------------------------
+    public Rule CompilationUnit() {
+        return FirstOf(
+                Sequence(
+                        Spacing(),
+                        Expression(),
+                        Spacing(),
+                        EOI
+                ),
+                push(error("Invalid program."))
+        );
+    }
+
+    // --------------------------------
+    // EXPRESSION
+    // --------------------------------
+    public Rule Expression() {
+        return FirstOf(
+                FunctionExpression(),
+                FunctionApplication(),
+                DoExpression(),
+                DefExpression(),
+                CondExpression(),
+
+                // Scalars
+                NilLiteral(),
+                NumberLiteral(),
+                BooleanLiteral(),
+                Symbol(),
+                Keyword(),
+
+                // Compound
+                Vector(),
+                MapLiteralExpression()
+        );
+    }
+
+    // --------------------------------
+    // FUNCTION
+    // --------------------------------
+
+    @SuppressWarnings("rawtypes")
+    public Rule FunctionExpression() {
+        return Sequence(
+                FN,
+                FunctionParameters(),
+                Spacing(),
+                FunctionBody(),
+                push(buildFunctionExpression((AVector) pop(), (Syntax) pop()))
+        );
+    }
+
+    @SuppressWarnings("rawtypes")
+    public Syntax buildFunctionExpression(AVector body, Syntax parameters) {
+        return Syntax.create(body.cons(parameters).cons(Syntax.create(Symbols.FN)));
+    }
+
+    public Rule FunctionName() {
+        return Optional(Symbol(), Spacing());
+    }
+
+    public Rule FunctionParameters() {
+        var expVar = new Var<>(new ArrayList<>());
+
+        return Sequence(
+                LPAR,
+                Spacing(),
+                Optional(
+                        OneOrMore(
+                                FunctionParameter(),
+                                ListAddAction(expVar)
+                        )
+                ),
+                RPAR,
+                push(prepare(Vectors.create(expVar.get())))
+        );
+    }
+
+    public Rule FunctionParameter() {
+        return Sequence(Symbol(), Spacing());
+    }
+
+    public Rule FunctionBody() {
+        var expVar = new Var<>(new ArrayList<>());
+
+        return Sequence(
+                LWING,
+                Spacing(),
+                Optional(
+                        OneOrMore(
+                                Expression(),
+                                Spacing(),
+                                ListAddAction(expVar)
+                        )
+                ),
+                RWING,
+                push(Vectors.create(expVar.get()))
+        );
+    }
+
+
+    // --------------------------------
+    // DO
+    // --------------------------------
+
+    /**
+     * Zero or more expressions wrapped in 'do { }'.
+     * <p>
+     * Compiles to '(do expression+ )'.
+     *
+     * @return Rule
+     */
+    public Rule DoExpression() {
+        return Sequence(
+                "do",
+                Spacing(),
+                LWING,
+                DoBody(),
+                RWING,
+                push(prepare(Lists.create(popNodeList()).cons(Symbols.DO)))
+        );
+    }
+
+    public Rule DoBody() {
+        Var<ArrayList<Object>> expVar = new Var<>(new ArrayList<>());
+
+        return Sequence(
+                ZeroOrMore(
+                        Spacing(),
+                        Expression(),
+                        Spacing(),
+                        ListAddAction(expVar)
+                ),
+                push(prepare(Lists.create(expVar.get())))
+        );
+    }
+
+    // --------------------------------
+    // COND
+    // --------------------------------
+    @SuppressWarnings({ "unchecked" })
+    public Rule CondExpression() {
+        return Sequence(
+                "cond",
+                Spacing(),
+                LWING,
+                CondTestExpressionList(),
+                RWING,
+                push(prepare(buildCondExpression((ArrayList<Object>) pop())))
+                
+        );
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public AList<Object> buildCondExpression(ArrayList<Object> testExpressionList) {
+        var pairs = Lists.create(testExpressionList).flatMap((pair) -> Lists.create((AList) pair));
+
+        return pairs.cons(Syntax.create(Symbols.COND));
+    }
+
+    public Rule CondTestExpressionList() {
+        var expVar = new Var<>(new ArrayList<>());
+
+        return OneOrMore(CondTestExpressionPair(), ListAddAction(expVar), push(expVar.get()));
+    }
+
+    public Rule CondTestExpressionPair() {
+        return Sequence(
+                Expression(),
+                Spacing(),
+                Expression(),
+                Spacing(),
+                push(buildCondTextExpression((Syntax) pop(), (Syntax) pop()))
+        );
+    }
+
+    public ASequence<Object> buildCondTextExpression(Syntax expression, Syntax test) {
+        return Lists.of(test, expression);
+    }
+
+    // --------------------------------
+    // DEF
+    // --------------------------------
+    public Rule DefExpression() {
+        return Sequence(
+                Spacing(),
+                "def",
+                Spacing(),
+                Symbol(),
+                Spacing(),
+                Expression(),
+                push(prepare(buildDefExpression((Syntax) pop(), (Syntax) pop())))
+        );
+    }
+
+    public List<Syntax> buildDefExpression(Syntax expr, Syntax sym) {
+        return (List<Syntax>) Lists.of(Syntax.create(Symbols.DEF), sym, expr);
+    }
+
+    public Rule Vector() {
+        return Sequence(
+                '[',
+                Spacing(),
+                CompoundExpressionList(),
+                Spacing(),
+                FirstOf(']', Sequence(FirstOf(AnyOf("})"), EOI), push(error("Expected closing ']'")))),
+                push(prepare(Vectors.create(popNodeList()))));
+    }
+
+    public Rule ExpressionStatement() {
+        return Sequence(CompoundExpression(), SEMI);
+    }
+
+    public Rule IfElseStatement() {
+        return Sequence(
+                IF,
+                IfTestExpression(),
+                Spacing(),
+                CompoundExpression(),
+                Spacing(),
+                Optional(
+                        ELSE,
+                        Statement()
+                ),
+                push(prepare(buildIfElseStatement((Syntax) pop(), (Syntax) pop())))
+        );
+    }
+
+    public List<Syntax> buildIfElseStatement(Syntax thenExpression, Syntax testExpression) {
+        return (List<Syntax>) Lists.of(Syntax.create(Symbols.COND), testExpression, thenExpression);
+    }
+
+    public Rule Statement() {
+        return FirstOf(
+                IfElseStatement(),
+                DefExpression(),
+                LocalSetStatement(),
+                ExpressionStatement()
+        );
+    }
+
+    public Rule LocalSetStatement() {
+        return Sequence(
+                Spacing(),
+                Symbol(),
+                EQU,
+                Expression(),
+                SEMI,
+                push(prepare(buildLocalSetStatement((Syntax) pop(), (Syntax) pop())))
+        );
+    }
+
+    public List<Syntax> buildLocalSetStatement(Syntax expr, Syntax sym) {
+        return (List<Syntax>) Lists.of(Syntax.create(Symbols.SET_BANG), sym, expr);
+    }
+
+    public Rule MapLiteralExpression() {
+        return Sequence(
+                LWING,
+                MapEntries(),
+                RWING,
+                // Create a Map from a List of MapEntry.
+                // `MapEntries` builds up a list of MapEntry,
+                // which we can get from `popNodeList`.
+                push(prepare(Maps.create(popNodeList())))
+        );
+    }
+
+    public Rule MapEntries() {
+        Var<ArrayList<Object>> expVar = new Var<>(new ArrayList<>());
+
+        return Sequence(
+                Optional(
+                        MapEntry(),
+                        ListAddAction(expVar),
+                        ZeroOrMore(
+                                COMMA,
+                                MapEntry(),
+                                ListAddAction(expVar))),
+                push(prepare(Lists.create(expVar.get()))));
+    }
+
+    public Rule MapEntry() {
+        return Sequence(
+                Expression(),
+                Spacing(),
+                Expression(),
+                push(buildMapEntry((Syntax) pop(), (Syntax) pop()))
+        );
+    }
+
+    public MapEntry<Syntax, Syntax> buildMapEntry(Syntax v, Syntax k) {
+        return MapEntry.create(k, v);
+    }
+
+    public Rule IfTestExpression() {
+        return CompoundExpression();
+    }
+
+    @SuppressWarnings("unchecked")
+    public Rule FunctionApplication() {
+        return Sequence(
+                Symbol(),
+                Spacing(),
+                FunctionApplicationArguments(),
+                push(prepare(buildFunctionApplication((ArrayList<Object>) pop(), (Syntax) pop())))
+        );
+    }
+
+    public ASequence<Object> buildFunctionApplication(ArrayList<Object> args, Syntax sym) {
+        return Lists.create(args).cons(sym);
+    }
+
+    Rule FunctionApplicationArguments() {
+        Var<ArrayList<Object>> expVar = new Var<>(new ArrayList<>());
+
+        return Sequence(
+                LPAR,
+                Optional(
+                        FunctionApplicationArgument(),
+                        ListAddAction(expVar),
+                        ZeroOrMore(
+                                FunctionApplicationArgument(),
+                                ListAddAction(expVar)
+                        )
+                ),
+                RPAR,
+                push(expVar.get())
+        );
+    }
+
+    Rule FunctionApplicationArgument() {
+        return Sequence(Expression(), Spacing());
+    }
+
+    public Rule InfixOperator() {
+        return FirstOf(
+                Sequence("+", push(Symbols.PLUS)),
+                Sequence("-", push(Symbols.MINUS)),
+                Sequence("*", push(Symbols.TIMES)),
+                Sequence("/", push(Symbols.DIVIDE)),
+                Sequence("==", push(Symbols.EQUALS)),
+                Sequence("<=", push(Symbols.LE)),
+                Sequence("<", push(Symbols.LT)),
+                Sequence(">=", push(Symbols.GE)),
+                Sequence(">", push(Symbols.GT))
+        );
+    }
+
+    public Rule InfixExtension() {
+        return Sequence(
+                Spacing(),
+                InfixOperator(),
+                Spacing(),
+                CompoundExpression(),
+                push(prepare(createInfixForm((Syntax) pop(), (Symbol) pop(), (Syntax) pop()))));
+    }
+
+    public List<Syntax> createInfixForm(Syntax op1, Symbol symbol, Syntax op2) {
+        return List.of(Syntax.create(symbol), op2, op1);
+    }
+
+    public Rule BinaryExpression() {
+        return Sequence(
+                Expression(),
+                Spacing(),
+                InfixOperator(),
+                Spacing(),
+                Expression(),
+                push(prepare(buildBinaryExpression((Syntax) pop(), (Symbol) pop(), (Syntax) pop())))
+        );
+    }
+
+    public List<Syntax> buildBinaryExpression(Syntax rhs, Symbol operator, Syntax lhs) {
+        return (List<Syntax>) Lists.of(Syntax.create(operator), lhs, rhs);
+    }
+
+    public Rule CompoundExpression() {
+        return FirstOf(
+                BinaryExpression(),
+                FunctionApplication(),
+                Sequence(
+                        Expression(),
+                        ZeroOrMore(Sequence(Spacing(), InfixExtension()))
+                )
+        );
+    }
+
+    public Rule CompoundExpressionList() {
+        Var<ArrayList<Object>> expVar = new Var<>(new ArrayList<>());
+        return Sequence(
+                Spacing(),
+                ZeroOrMore(
+                        Sequence( // initial expressions with following whitespace or delimiter
+                                CompoundExpression(),
+                                COMMA,
+                                ListAddAction(expVar))),
+                Optional(
+                        Sequence( // final expression without whitespace
+                                CompoundExpression(), ListAddAction(expVar))),
+                push(prepare(Lists.create(expVar.get()))));
+    }
+
+    public Rule HexDigit() {
+        return FirstOf(CharRange('a', 'f'), CharRange('A', 'F'), CharRange('0', '9'));
+    }
+
+    Rule UnicodeEscape() {
+        return Sequence(OneOrMore('u'), HexDigit(), HexDigit(), HexDigit(), HexDigit());
+    }
+
+    @MemoMismatches
+    Rule LetterOrDigit() {
+        return FirstOf(Sequence('\\', UnicodeEscape()), new ScryptLetterOrDigitMatcher());
+    }
+
+    @SuppressNode
+    @DontLabel
+    Rule Keyword(String keyword) {
+        return Terminal(keyword, LetterOrDigit());
+    }
+
+    @SuppressNode
+    @DontLabel
+    Rule Terminal(String string) {
+        return Sequence(Spacing(), string, Spacing()).label('\'' + string + '\'');
+    }
+
+    @SuppressNode
+    @DontLabel
+    Rule Terminal(String string, Rule mustNotFollow) {
+        return Sequence(Spacing(), string, TestNot(mustNotFollow), Spacing()).label('\'' + string + '\'');
+    }
+
+    public Rule Spacing() {
+        return ZeroOrMore(FirstOf(
+
+                // whitespace
+                OneOrMore(AnyOf(" \t\r\n\f").label("Whitespace")),
+
+                // traditional comment
+                Sequence("/*", ZeroOrMore(TestNot("*/"), ANY), "*/"),
+
+                // end of line comment
+                Sequence(
+                        "//",
+                        ZeroOrMore(TestNot(AnyOf("\r\n")), ANY),
+                        FirstOf("\r\n", '\r', '\n', EOI)
+                )
+        ));
+    }
+
+}

--- a/src/main/java/convex/core/lang/Scrypt3.java
+++ b/src/main/java/convex/core/lang/Scrypt3.java
@@ -1,0 +1,573 @@
+package convex.core.lang;
+
+import convex.core.data.*;
+import org.parboiled.Parboiled;
+import org.parboiled.Rule;
+import org.parboiled.annotations.BuildParseTree;
+import org.parboiled.annotations.DontLabel;
+import org.parboiled.annotations.MemoMismatches;
+import org.parboiled.annotations.SuppressNode;
+import org.parboiled.parserunners.ReportingParseRunner;
+import org.parboiled.support.Var;
+
+import java.util.ArrayList;
+
+@BuildParseTree
+public class Scrypt3 extends Reader {
+
+    // Use a ThreadLocal reader because instances are not thread safe
+    private static final ThreadLocal<Scrypt3> syntaxReader = ThreadLocal.withInitial(() -> Parboiled.createParser(Scrypt3.class));
+    public final Rule DEF = Keyword("def");
+    public final Rule COND = Keyword("cond");
+    public final Rule FN = Keyword("fn");
+    public final Rule IF = Keyword("if");
+    public final Rule ELSE = Keyword("else");
+    public final Rule WHEN = Keyword("when");
+    public final Rule DO = Keyword("do");
+
+    final Rule EQU = Terminal("=", Ch('='));
+    final Rule COMMA = Terminal(",");
+    final Rule LPAR = Terminal("(");
+    final Rule RPAR = Terminal(")");
+    final Rule LWING = Terminal("{");
+    final Rule RWING = Terminal("}");
+    final Rule LBRK = Terminal("[");
+    final Rule RBRK = Terminal("]");
+    final Rule SEMI = Terminal(";");
+    final Rule RIGHT_ARROW = Terminal("->");
+
+    /**
+     * Constructor for reader class. Called by Parboiled.createParser
+     */
+    public Scrypt3() {
+        super(true);
+    }
+
+    /**
+     * Parses an expression and returns a Syntax object
+     *
+     * @param source
+     * @return Parsed form
+     */
+    @SuppressWarnings("rawtypes")
+    public static Syntax readSyntax(String source) {
+        Scrypt3 scryptReader = syntaxReader.get();
+        scryptReader.tempSource = source;
+
+        var rule = scryptReader.CompilationUnit();
+        var result = new ReportingParseRunner(rule).run(source);
+
+        if (result.matched) {
+            return (Syntax) result.resultValue;
+        } else {
+            throw new RuntimeException(rule.toString() + " failed to match " + source);
+        }
+    }
+
+    // --------------------------------
+    // COMPILATION UNIT
+    // --------------------------------
+    public Rule CompilationUnit() {
+        return FirstOf(
+                Sequence(
+                        Spacing(),
+                        FirstOf(
+                                Sequence(Expression(), EOI),
+                                Sequence(Statement(), EOI),
+                                Sequence(StatementList(), push(prepare(popNodeList().cons(Syntax.create(Symbols.DO)))), EOI)
+                        )
+                ),
+                push(error("Invalid program."))
+        );
+    }
+
+    // --------------------------------
+    // STATEMENT
+    // --------------------------------
+    public Rule Statement() {
+        return FirstOf(
+                IfElseExpression(),
+                WhenStatement(),
+                Sequence(DefExpression(), SEMI),
+                Sequence(Expression(), SEMI),
+                BlockExpression(),
+                Sequence(SEMI, push(prepare(null)))
+        );
+    }
+
+    // --------------------------------
+    // EXPRESSION
+    // --------------------------------
+    public Rule Expression() {
+        return Sequence(
+                FirstOf(// Special
+                        DefExpression(),
+                        CondExpression(),
+                        DoExpression(),
+
+                        CallableExpression(),
+                        FnExpression(),
+                        LambdaExpression(),
+
+                        // Scalars
+                        StringLiteral(),
+                        NilLiteral(),
+                        NumberLiteral(),
+                        BooleanLiteral(),
+                        Symbol(),
+                        Keyword(),
+
+                        // Compound
+                        VectorExpression(),
+                        MapExpression(),
+                        Set(),
+
+                        BlockExpression()
+                ),
+                Spacing()
+        );
+    }
+
+    // --------------------------------
+    // INFIX
+    // --------------------------------
+
+    public Rule InfixExpression() {
+        return Sequence(
+                Expression(),
+                InfixOperator(),
+                Expression(),
+                ZeroOrMore(InfixOperator(), Expression())
+        );
+    }
+
+    // --------------------------------
+    // FUNCTION
+    // --------------------------------
+    public Rule FnExpression() {
+        return Sequence(
+                FN,
+                ParOptMany(Symbol()),
+                Block(),
+                push(buildFnExpression())
+        );
+    }
+
+    public Syntax buildFnExpression() {
+        var block = popNodeList();
+        var parameters = Vectors.create(popNodeList());
+
+        return Syntax.create(block.cons(parameters).cons(Syntax.create(Symbols.FN)));
+    }
+
+    // --------------------------------
+    // LAMBDA
+    // --------------------------------
+    public Rule LambdaExpression() {
+        return Sequence(
+                // Args []
+                ParOptMany(Symbol()),
+                // ->
+                RIGHT_ARROW,
+                // Body
+                Expression(),
+                push(prepare(lambdaExpression()))
+        );
+    }
+
+    public AList<Object> lambdaExpression() {
+        var fn = Syntax.create(Symbols.FN);
+        var body = pop();
+        var args = Vectors.create(popNodeList());
+
+        return Lists.of(fn, args, body);
+    }
+
+    // --------------------------------
+    // BLOCK
+    // --------------------------------
+    public Rule BlockExpression() {
+        return Sequence(Block(), push(prepare(popNodeList().cons(Syntax.create(Symbols.DO)))));
+    }
+
+    public Rule Block() {
+        return Sequence(
+                LWING,
+                StatementList(),
+                RWING
+        );
+    }
+
+    public Rule StatementList() {
+        Var<ArrayList<Object>> expVar = new Var<>(new ArrayList<>());
+
+        return Sequence(
+                ZeroOrMore(
+                        Statement(),
+                        ListAddAction(expVar)
+                ),
+                push(prepare(Lists.create(expVar.get())))
+        );
+    }
+
+    // --------------------------------
+    // DO
+    // --------------------------------
+    public Rule DoExpression() {
+        return Sequence(
+                DO,
+                BlockExpression()
+        );
+    }
+
+    // --------------------------------
+    // COND
+    // --------------------------------
+    @SuppressWarnings({"unchecked"})
+    public Rule CondExpression() {
+        return Sequence(
+                COND,
+                LWING,
+                CondTestExpressionList(),
+                RWING,
+                push(prepare(buildCondExpression((ArrayList<Object>) pop())))
+
+        );
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public AList<Object> buildCondExpression(ArrayList<Object> testExpressionList) {
+        var pairs = Lists.create(testExpressionList).flatMap((pair) -> Lists.create((AList) pair));
+
+        return pairs.cons(Syntax.create(Symbols.COND));
+    }
+
+    public Rule CondTestExpressionList() {
+        var expVar = new Var<>(new ArrayList<>());
+
+        return Sequence(
+                CondTestExpressionPair(),
+                ListAddAction(expVar),
+                ZeroOrMore(
+                        COMMA,
+                        CondTestExpressionPair(),
+                        ListAddAction(expVar)
+
+                ),
+                push(expVar.get())
+        );
+    }
+
+    public Rule CondTestExpressionPair() {
+        return Sequence(
+                Expression(),
+                Expression(),
+                push(buildCondTextExpression())
+        );
+    }
+
+    public ASequence<Object> buildCondTextExpression() {
+        var expression = pop();
+        var test = pop();
+
+        return Lists.of(test, expression);
+    }
+
+    // --------------------------------
+    // WHEN
+    // --------------------------------
+    public Rule WhenStatement() {
+        return Sequence(
+                WHEN,
+                ParExpression(),
+                Block(),
+                push(prepare(buildWhenExpression()))
+        );
+    }
+
+    @SuppressWarnings("rawtypes")
+    public ASequence buildWhenExpression() {
+        // Pop expressions from body
+        var body = popNodeList();
+
+        // Pop test
+        var test = (Syntax) pop();
+
+        return body.cons(test).cons(Symbols.WHEN);
+    }
+
+    // --------------------------------
+    // IF ELSE
+    // --------------------------------
+    // TODO Need separate IfElseStatement?
+    public Rule IfElseExpression() {
+        return FirstOf(
+                Sequence(
+                        IF,
+                        ParExpression(),
+                        Expression(),
+                        ELSE,
+                        Expression(),
+                        push(prepare(buildIfElseExpression()))
+                ),
+                Sequence(
+                        IF,
+                        ParExpression(),
+                        Expression(),
+                        push(prepare(buildIfExpression()))
+                )
+        );
+    }
+
+    @SuppressWarnings("rawtypes")
+    public ASequence buildIfExpression() {
+        // Pop expressions from if body
+        var body = pop();
+
+        // Pop test
+        var test = (Syntax) pop();
+
+        return Lists.of(
+                Syntax.create(Symbols.IF),
+                test,
+                body
+        );
+    }
+
+    @SuppressWarnings("rawtypes")
+    public ASequence buildIfElseExpression() {
+        // Pop expressions from else body
+        var elseBody = pop();
+
+        // Pop expressions from if body
+        var ifBody = pop();
+
+        // Pop test
+        var test = (Syntax) pop();
+
+        return Lists.of(
+                Syntax.create(Symbols.IF),
+                test,
+                ifBody,
+                elseBody
+        );
+    }
+
+
+    // --------------------------------
+    // DEF
+    // --------------------------------
+    public Rule DefExpression() {
+        return Sequence(
+                DEF,
+                Symbol(),
+                Spacing(),
+                EQU,
+                Expression(),
+                push(prepare(buildDefExpression((Syntax) pop(), (Syntax) pop())))
+        );
+    }
+
+    public List<Syntax> buildDefExpression(Syntax expr, Syntax sym) {
+        return (List<Syntax>) Lists.of(Syntax.create(Symbols.DEF), sym, expr);
+    }
+
+    public Rule VectorExpression() {
+        return Sequence(
+                LBRK,
+                OptManyCommaSeparated(Expression()),
+                FirstOf(
+                        RBRK,
+                        Sequence(
+                                FirstOf(RWING, RPAR, EOI),
+                                push(error("Expected closing ']'"))
+                        )
+                ),
+                Spacing(),
+                push(prepare(Vectors.create(popNodeList()))));
+    }
+
+    public Rule MapExpression() {
+        return Sequence(
+                LWING,
+                MapEntries(),
+                RWING,
+                Spacing(),
+                // Create a Map from a List of MapEntry.
+                // `MapEntries` builds up a list of MapEntry,
+                // which we can get from `popNodeList`.
+                push(prepare(Maps.create(popNodeList())))
+        );
+    }
+
+    public Rule MapEntries() {
+        Var<ArrayList<Object>> expVar = new Var<>(new ArrayList<>());
+
+        return Sequence(
+                Optional(
+                        MapEntry(),
+                        ListAddAction(expVar),
+                        ZeroOrMore(
+                                COMMA,
+                                MapEntry(),
+                                ListAddAction(expVar))),
+                push(prepare(Lists.create(expVar.get()))));
+    }
+
+    public Rule MapEntry() {
+        return Sequence(
+                Expression(),
+                Spacing(),
+                Expression(),
+                push(buildMapEntry((Syntax) pop(), (Syntax) pop()))
+        );
+    }
+
+    public MapEntry<Syntax, Syntax> buildMapEntry(Syntax v, Syntax k) {
+        return MapEntry.create(k, v);
+    }
+
+    public Rule Callable() {
+        return FirstOf(
+                FnExpression(),
+                VectorExpression(),
+                MapExpression(),
+                Set()
+        );
+    }
+
+    public Rule CallableExpression() {
+        return Sequence(
+                FirstOf(
+                        Callable(),
+                        Symbol()
+                ),
+                Spacing(),
+                ParOptMany(Expression()),
+                push(prepare(callableExpression()))
+        );
+    }
+
+    public ASequence<Object> callableExpression() {
+        var args = popNodeList();
+        var callableOrSym = pop();
+
+        return Lists.create(args).cons(callableOrSym);
+    }
+
+    public Rule InfixOperator() {
+        return FirstOf(
+                Sequence("+", push(Symbols.PLUS)),
+                Sequence("-", push(Symbols.MINUS)),
+                Sequence("*", push(Symbols.TIMES)),
+                Sequence("/", push(Symbols.DIVIDE)),
+                Sequence("==", push(Symbols.EQUALS)),
+                Sequence("<=", push(Symbols.LE)),
+                Sequence("<", push(Symbols.LT)),
+                Sequence(">=", push(Symbols.GE)),
+                Sequence(">", push(Symbols.GT))
+        );
+    }
+
+    public Rule InfixExtension() {
+        return Sequence(
+                Spacing(),
+                InfixOperator(),
+                Spacing(),
+                CompoundExpression(),
+                push(prepare(createInfixForm((Syntax) pop(), (Symbol) pop(), (Syntax) pop()))));
+    }
+
+    public List<Syntax> createInfixForm(Syntax op1, Symbol symbol, Syntax op2) {
+        return List.of(Syntax.create(symbol), op2, op1);
+    }
+
+    public Rule CompoundExpression() {
+        return FirstOf(
+                CallableExpression(),
+                Sequence(
+                        Expression(),
+                        ZeroOrMore(Sequence(Spacing(), InfixExtension()))
+                )
+        );
+    }
+
+    public Rule HexDigit() {
+        return FirstOf(CharRange('a', 'f'), CharRange('A', 'F'), CharRange('0', '9'));
+    }
+
+    Rule UnicodeEscape() {
+        return Sequence(OneOrMore('u'), HexDigit(), HexDigit(), HexDigit(), HexDigit());
+    }
+
+    @MemoMismatches
+    Rule LetterOrDigit() {
+        return FirstOf(Sequence('\\', UnicodeEscape()), new ScryptLetterOrDigitMatcher());
+    }
+
+    @SuppressNode
+    @DontLabel
+    Rule Keyword(String keyword) {
+        return Terminal(keyword, LetterOrDigit());
+    }
+
+    @SuppressNode
+    @DontLabel
+    Rule Terminal(String string) {
+        return Sequence(string, Spacing()).label('\'' + string + '\'');
+    }
+
+    @SuppressNode
+    @DontLabel
+    Rule Terminal(String string, Rule mustNotFollow) {
+        return Sequence(string, TestNot(mustNotFollow), Spacing()).label('\'' + string + '\'');
+    }
+
+    public Rule Spacing() {
+        return ZeroOrMore(FirstOf(
+
+                // whitespace
+                OneOrMore(AnyOf(" \t\r\n\f").label("Whitespace")),
+
+                // traditional comment
+                Sequence("/*", ZeroOrMore(TestNot("*/"), ANY), "*/"),
+
+                // end of line comment
+                Sequence(
+                        "//",
+                        ZeroOrMore(TestNot(AnyOf("\r\n")), ANY),
+                        FirstOf("\r\n", '\r', '\n', EOI)
+                )
+        ));
+    }
+
+    public Rule ParExpression() {
+        return Sequence(LPAR, Expression(), RPAR);
+    }
+
+    public Rule ParOptMany(Rule rule) {
+        return Sequence(
+                LPAR,
+                OptManyCommaSeparated(rule),
+                RPAR
+        );
+    }
+
+    public Rule OptManyCommaSeparated(Rule rule) {
+        Var<ArrayList<Object>> expVar = new Var<>(new ArrayList<>());
+
+        return Sequence(
+                Optional(
+                        rule,
+                        ListAddAction(expVar),
+                        ZeroOrMore(
+                                COMMA,
+                                rule,
+                                ListAddAction(expVar)
+                        )
+                ),
+                push(prepare(Lists.create(expVar.get())))
+        );
+    }
+
+}

--- a/src/main/java/convex/core/lang/ScryptLetterOrDigitMatcher.java
+++ b/src/main/java/convex/core/lang/ScryptLetterOrDigitMatcher.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2009-2011 Mathias Doenitz
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package convex.core.lang;
+
+public class ScryptLetterOrDigitMatcher extends AbstractScryptCharacterMatcher {
+
+    public ScryptLetterOrDigitMatcher() {
+        super("LetterOrDigit");
+    }
+
+    @Override
+    protected boolean acceptChar(char c) {
+        return Character.isJavaIdentifierPart(c);
+    }
+}

--- a/src/main/java/convex/core/lang/Symbols.java
+++ b/src/main/java/convex/core/lang/Symbols.java
@@ -74,6 +74,7 @@ public class Symbols {
 	public static final Symbol EXPANDER = Symbol.create("expander");
 
 	public static final Symbol IF = Symbol.create("if");
+	public static final Symbol WHEN = Symbol.create("when");
 	public static final Symbol LET = Symbol.create("let");
 
 	public static final Symbol STORE = Symbol.create("store");

--- a/src/test/java/convex/core/lang/Scrypt2Test.java
+++ b/src/test/java/convex/core/lang/Scrypt2Test.java
@@ -1,0 +1,137 @@
+package convex.core.lang;
+
+import convex.core.data.Syntax;
+import org.junit.jupiter.api.Test;
+import org.parboiled.Parboiled;
+import org.parboiled.Rule;
+import org.parboiled.errors.ParserRuntimeException;
+import org.parboiled.parserunners.ReportingParseRunner;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class Scrypt2Test {
+
+    static final Context<?> CONTEXT = TestState.INITIAL_CONTEXT;
+
+    static Scrypt2 scrypt() {
+        return Parboiled.createParser(Scrypt2.class);
+    }
+
+    @SuppressWarnings("rawtypes")
+    static Object parse(Rule rule, String source) {
+        var result = new ReportingParseRunner(rule).run(source);
+
+        if (result.matched) {
+            return Syntax.unwrapAll(result.resultValue);
+        } else {
+            throw new RuntimeException(rule.toString() + " failed to match " + source);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> Context<T> step(Context<?> c, String source) {
+        Syntax syn = Scrypt2.readSyntax(source);
+
+        Context<AOp<Object>> cctx = c.expandCompile(syn);
+
+        if (cctx.isExceptional()) return (Context<T>) cctx;
+
+        AOp<Object> op = cctx.getResult();
+
+        return (Context<T>) c.run(op);
+    }
+
+    public static <T> Context<T> step(String source) {
+        return step(CONTEXT, source);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> T eval(String source) {
+        return (T) step(CONTEXT, source).getResult();
+    }
+
+
+    @Test
+    public void testExpressions() {
+        var scrypt = scrypt();
+
+        var compilationUnit = scrypt.CompilationUnit();
+
+        assertThrows(ParserRuntimeException.class, () -> parse(compilationUnit, ""));
+        assertThrows(ParserRuntimeException.class, () -> parse(compilationUnit, "1 true"));
+        assertThrows(ParserRuntimeException.class, () -> parse(compilationUnit, "{"));
+        assertThrows(ParserRuntimeException.class, () -> parse(compilationUnit, "def x"));
+        assertThrows(ParserRuntimeException.class, () -> parse(compilationUnit, "inc(1"));
+        assertThrows(ParserRuntimeException.class, () -> parse(compilationUnit, "cond { }"));
+
+        // Scalar Data Types
+        assertEquals(Reader.read("nil"), parse(compilationUnit, "nil"));
+        assertEquals(Reader.read("1"), parse(compilationUnit, "1"));
+        assertEquals(Reader.read("true"), parse(compilationUnit, "true"));
+        assertEquals(Reader.read("false"), parse(compilationUnit, "false"));
+        assertEquals(Reader.read("symbol"), parse(compilationUnit, "symbol"));
+        assertEquals(Reader.read(":keyword"), parse(compilationUnit, ":keyword"));
+
+        // Compound Data Types
+        assertEquals(Reader.read("[]"), parse(compilationUnit, "[]"));
+        assertEquals(Reader.read("{}"), parse(compilationUnit, "{}"));
+
+        // Function Application
+        assertEquals(Reader.read("(inc 1)"), parse(compilationUnit, "inc(1)"));
+        assertEquals(Reader.read("(inc (inc 1))"), parse(compilationUnit, "inc(inc(1))"));
+        assertEquals(Reader.read("(map inc [1,2])"), parse(compilationUnit, "map(inc [1, 2])"));
+        assertEquals(Reader.read("(map (fn [x] x) [1,2])"), parse(compilationUnit, "map(fn(x){x} [1, 2])"));
+        assertEquals(Reader.read("(reduce (fn [acc,x] (conj acc x)) [] [1,2])"), parse(compilationUnit, "reduce(fn(acc x){ conj(acc x) } [] [1, 2])"));
+
+        // Do Expression
+        assertEquals(Reader.read("(do)"), parse(compilationUnit, "do { }"));
+        assertEquals(Reader.read("(do 1)"), parse(compilationUnit, "do { 1 }"));
+        assertEquals(Reader.read("(do 1 (inc 2) {:n 3})"), parse(compilationUnit, "do { 1 inc(2) {:n 3} }"));
+        assertEquals(Reader.read("(do (def f (fn [x] x)) (f 1))"), parse(compilationUnit, "do { def f fn(x) { x } f(1) }"));
+        assertEquals(1, (Long) eval("do { 1 }"));
+
+        // Def Expression
+        assertEquals(Reader.read("(def x 1)"), parse(compilationUnit, "def x 1"));
+        assertEquals(Reader.read("(def x (inc 1))"), parse(compilationUnit, "def x inc(1)"));
+        assertEquals(Reader.read("(def x (do (reduce + [] [1,2,3])))"), parse(compilationUnit, "def x do { reduce(+ [] [1, 2, 3]) }"));
+        assertEquals(Reader.read("(def f (fn []))"), parse(compilationUnit, "def f fn(){}"));
+
+        // Cond Expression
+        assertEquals(Reader.read("(cond false 1)"), parse(compilationUnit, "cond { false 1 }"));
+        assertEquals(Reader.read("(cond (zero? x) 1)"), parse(compilationUnit, "cond { zero?(x) 1 }"));
+        assertEquals(Reader.read("(cond false 1 (inc 1) 2)"), parse(compilationUnit, "cond { false 1  inc(1) 2 }"));
+        assertEquals(2, (Long) eval("cond { false 1 :default 2 }"));
+        assertEquals(2, (Long) eval("cond { true inc(1) }"));
+        assertEquals(2, (Long) eval("cond { false 1 :default 2 }"));
+        assertEquals(2, (Long) eval("cond { false 1  inc(1) 2 }"));
+        assertNull(eval("cond { false 1  nil 2 }"));
+
+        // Function Expression
+        assertEquals(Reader.read("(fn [])"), parse(compilationUnit, "fn ( ) { }"));
+        assertEquals(Reader.read("(fn [x])"), parse(compilationUnit, "fn (x) { }"));
+        assertEquals(Reader.read("(fn [x y])"), parse(compilationUnit, "fn (x y) { }"));
+        assertEquals(Reader.read("(fn [x] x)"), parse(compilationUnit, "fn (x) { x }"));
+        assertEquals(Reader.read("(fn [x] 1 {} [] (inc x))"), parse(compilationUnit, "fn (x) { 1 {} [] inc(x) }"));
+
+        /**
+         * 1 + inc(5) / 2
+         * (1 + inc(5)) / 2
+         */
+
+
+        /**
+         * defn identity(x) {
+         *   x
+         * }
+         */
+
+        /**
+         * let (x 1 y 2) {
+         *   x + y
+         * }
+         * 
+         */
+
+    }
+
+}

--- a/src/test/java/convex/core/lang/Scrypt3Test.java
+++ b/src/test/java/convex/core/lang/Scrypt3Test.java
@@ -1,0 +1,181 @@
+package convex.core.lang;
+
+import convex.core.data.Maps;
+import convex.core.data.Syntax;
+import org.junit.jupiter.api.Test;
+import org.parboiled.Parboiled;
+import org.parboiled.Rule;
+import org.parboiled.errors.ParserRuntimeException;
+import org.parboiled.parserunners.ReportingParseRunner;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class Scrypt3Test {
+
+    static final Context<?> CONTEXT = TestState.INITIAL_CONTEXT;
+
+    static Scrypt3 scrypt() {
+        return Parboiled.createParser(Scrypt3.class);
+    }
+
+    @SuppressWarnings("rawtypes")
+    static Object parse(Rule rule, String source) {
+        var result = new ReportingParseRunner(rule).run(source);
+
+        if (result.matched) {
+            return Syntax.unwrapAll(result.resultValue);
+        } else {
+            throw new RuntimeException(rule.toString() + " failed to match " + source);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> Context<T> step(Context<?> c, String source) {
+        Syntax syn = Scrypt3.readSyntax(source);
+
+        Context<AOp<Object>> cctx = c.expandCompile(syn);
+
+        if (cctx.isExceptional()) return (Context<T>) cctx;
+
+        AOp<Object> op = cctx.getResult();
+
+        return (Context<T>) c.run(op);
+    }
+
+    public static <T> Context<T> step(String source) {
+        return step(CONTEXT, source);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> T eval(String source) {
+        return (T) step(CONTEXT, source).getResult();
+    }
+
+
+    @Test
+    public void testExpressions() {
+        var scrypt = scrypt();
+
+        var compilationUnit = scrypt.CompilationUnit();
+
+        assertThrows(ParserRuntimeException.class, () -> parse(compilationUnit, "1 true"));
+        assertThrows(ParserRuntimeException.class, () -> parse(compilationUnit, "{"));
+        assertThrows(ParserRuntimeException.class, () -> parse(compilationUnit, "def x"));
+        assertThrows(ParserRuntimeException.class, () -> parse(compilationUnit, "inc(1"));
+        assertThrows(ParserRuntimeException.class, () -> parse(compilationUnit, "cond { }"));
+
+        // Scalar Data Types
+        assertEquals(Reader.read("nil"), parse(compilationUnit, "nil"));
+        assertEquals(Reader.read("\"Hello\""), parse(compilationUnit, "\"Hello\""));
+        assertEquals(Reader.read("1"), parse(compilationUnit, "1"));
+        assertEquals(Reader.read("true"), parse(compilationUnit, "true"));
+        assertEquals(Reader.read("false"), parse(compilationUnit, "false"));
+        assertEquals(Reader.read("symbol"), parse(compilationUnit, "symbol"));
+        assertEquals(Reader.read(":keyword"), parse(compilationUnit, ":keyword"));
+
+        // Compound Data Types
+        assertEquals(Reader.read("[]"), parse(compilationUnit, "[]"));
+        assertEquals(Reader.read("{}"), parse(compilationUnit, "{}"));
+        assertEquals(Reader.read("{}"), parse(compilationUnit, "{};"));
+        assertEquals(Reader.read("#{}"), parse(compilationUnit, "#{}"));
+
+        // Block Expression
+        assertEquals(Reader.read("(do 1)"), parse(compilationUnit, "{ 1; }"));
+        assertEquals(Reader.read("(do 1 (inc 2) {:n 3})"), parse(compilationUnit, "{ 1; inc(2); {:n 3}; }"));
+        assertEquals(Reader.read("(do (def f (fn [x] x)) (f 1))"), parse(compilationUnit, "{ def f = fn(x) { x; }; f(1); }"));
+        assertEquals(Reader.read("(do (def x? true) (if x? (do 1 2)) 1)"), parse(compilationUnit, "do { def x? = true; if (x?) { 1; 2; } 1; }"));
+        assertEquals(Reader.read("(do (def x? true) (when x? 1) 1)"), parse(compilationUnit, "do { def x? = true; when (x?) { 1; } 1; }"));
+        assertEquals(2, (Long) eval("{ inc(1); }"));
+
+        // Do Expression
+        assertEquals(Reader.read("(do)"), parse(compilationUnit, "do { }"));
+        assertEquals(Reader.read("(do 1)"), parse(compilationUnit, "do { 1; }"));
+        assertEquals(Reader.read("(do 1 (inc 2) {:n 3})"), parse(compilationUnit, "do { 1; inc(2); {:n 3}; }"));
+        assertEquals(Reader.read("(do (def f (fn [x] x)) (f 1))"), parse(compilationUnit, "do { def f = fn(x) { x; }; f(1); }"));
+        assertNull(eval("do { }"));
+        assertEquals(1, (Long) eval("do { 1; }"));
+
+        // Def Expression
+        assertEquals(Reader.read("(def x 1)"), parse(compilationUnit, "def x = 1"));
+        assertEquals(Reader.read("(def f (fn [x xs] (conj xs x)))"), parse(compilationUnit, "def f = (x, xs) -> conj(xs, x)"));
+
+        // TODO Do we want to allow this?
+        assertEquals(Reader.read("(def x (def y 1))"), parse(compilationUnit, "def x = def y = 1"));
+
+        assertEquals(Reader.read("(def x (inc 1))"), parse(compilationUnit, "def x = inc(1)"));
+        assertEquals(Reader.read("(def x (do (reduce + [] [1,2,3])))"), parse(compilationUnit, "def x = do { reduce(+, [], [1, 2, 3]); }"));
+        assertEquals(Reader.read("(def f (fn []))"), parse(compilationUnit, "def f = fn(){}"));
+
+        // Cond Expression
+        assertEquals(Reader.read("(cond false 1)"), parse(compilationUnit, "cond { false 1 }"));
+        assertEquals(Reader.read("(cond (zero? x) 1)"), parse(compilationUnit, "cond { zero?(x) 1 }"));
+        assertEquals(Reader.read("(cond false 1 (inc 1) 2)"), parse(compilationUnit, "cond { false 1,  inc(1) 2 }"));
+        assertEquals(2, (Long) eval("cond { false 1, :default 2 }"));
+        assertEquals(2, (Long) eval("cond { true inc(1) }"));
+        assertEquals(2, (Long) eval("cond { false 1, :default 2 }"));
+        assertEquals(2, (Long) eval("cond { false 1,  inc(1) 2 }"));
+        assertNull(eval("cond { false 1,  nil 2 }"));
+
+        // When Expression
+        assertEquals(Reader.read("(when true 1)"), parse(compilationUnit, "when (true) { 1; }"));
+        assertEquals(Reader.read("(when true)"), parse(compilationUnit, "when (true) {}"));
+        assertEquals(Reader.read("(when true (f 1) 2)"), parse(compilationUnit, "when (true) { f(1); 2; }"));
+
+        // If Else Expression
+        assertEquals(Reader.read("(if true 1)"), parse(compilationUnit, "if (true) 1"));
+        assertEquals(Reader.read("(if true 1 2)"), parse(compilationUnit, "if (true) 1 else 2"));
+        assertEquals(Reader.read("(if true (do 1 2))"), parse(compilationUnit, "if (true) { 1; 2; }"));
+        assertEquals(Reader.read("(if true (do 1 2) (do 3 4))"), parse(compilationUnit, "if (true) { 1; 2; } else { 3; 4; }"));
+        assertSame(Maps.empty(), eval("if (true) {}"));
+
+        // Function Expression
+        assertEquals(Reader.read("(fn [])"), parse(compilationUnit, "fn ( ) { }"));
+        assertEquals(Reader.read("(fn [x])"), parse(compilationUnit, "fn (x) { }"));
+        assertEquals(Reader.read("(fn [x y])"), parse(compilationUnit, "fn (x, y) { }"));
+        assertEquals(Reader.read("(fn [x] x)"), parse(compilationUnit, "fn (x) { x; }"));
+        assertEquals(Reader.read("(fn [x y] x y)"), parse(compilationUnit, "fn (x, y) { x; y; }"));
+        assertEquals(Reader.read("(fn [x] 1 {} [] (inc x))"), parse(compilationUnit, "fn (x) { 1; {}; []; inc(x); }"));
+
+        // Lambda Expression
+        assertEquals(Reader.read("(fn [] nil)"), parse(compilationUnit, "() -> nil"));
+        assertEquals(Reader.read("(fn [x] x)"), parse(compilationUnit, "(x) -> x"));
+        assertEquals(Reader.read("(fn [x xs] (conj xs x))"), parse(compilationUnit, "(x, xs) -> conj(xs, x)"));
+
+        // Callable Expression
+        assertEquals(Reader.read("(f)"), parse(compilationUnit, "f()"));
+        assertEquals(Reader.read("([] 0)"), parse(compilationUnit, "[](0)"));
+        assertEquals(Reader.read("({} :key)"), parse(compilationUnit, "{}(:key)"));
+        assertEquals(Reader.read("(#{} x)"), parse(compilationUnit, "#{}(x)"));
+        assertEquals(Reader.read("((fn [] nil))"), parse(compilationUnit, "fn(){;}()"));
+        assertEquals(Reader.read("((fn [x] x) 1)"), parse(compilationUnit, "fn(x){x;}(1)"));
+        assertEquals(Reader.read("(inc 1)"), parse(compilationUnit, "inc(1)"));
+        assertEquals(Reader.read("(inc (inc 1))"), parse(compilationUnit, "inc(inc(1))"));
+        assertEquals(Reader.read("(map inc [1,2])"), parse(compilationUnit, "map(inc, [1, 2])"));
+        assertEquals(Reader.read("(map (fn [x] x) [1,2])"), parse(compilationUnit, "map(fn(x){x;}, [1, 2])"));
+        assertEquals(Reader.read("(map (fn [x] x) [1,2])"), parse(compilationUnit, "map((x) -> x, [1, 2])"));
+        assertEquals(Reader.read("(reduce (fn [acc,x] (conj acc x)) [] [1,2])"), parse(compilationUnit, "reduce(fn(acc, x){ conj(acc, x); }, [], [1, 2])"));
+        assertEquals(Reader.read("(reduce (fn [acc,x] (conj acc x)) [] [1,2])"), parse(compilationUnit, "reduce((acc, x) -> conj(acc, x), [], [1, 2])"));
+
+        // Statements
+        assertEquals(Reader.read("(do (def x 1) (def y 2))"), parse(compilationUnit, "def x = 1; def y = 2;"));
+        assertEquals(Reader.read("(do (def x 1) (if (zero? x) :zero :not-zero) nil 2)"), parse(compilationUnit, "def x = 1; if(zero?(x)) :zero else :not-zero; 2;"));
+
+
+        /* TODO
+
+        1 + inc(5) / 2
+        (1 + inc(5)) / 2
+
+        defn identity(x) {
+          x
+        }
+
+        let (x 1 y 2) {
+          x + y
+        }
+
+        */
+
+    }
+
+}


### PR DESCRIPTION
The parser was rewritten and some syntax was changed.

**Data types**
- boolean;
- number;
- string;
- symbol;
- keyword;
- map;
- vector;
- set;

**Variable definition**
`def x = 1`

**Function expression**
`fn f(x) {x;}`

**Lambda expression**
`(x) -> x`

**If/else statement**
`if (test) x else y`
`if (test) { x; y; } else { y; z; }`

**When statement**
`when (test) { inc(x); map(inc, [1, 2]); }`

**Cond statement**
`cond { test1 expr1, test2 expr2 }`