### PR TITLE
add owner address to peer status

### DIFF
--- a/src/main/java/convex/core/Init.java
+++ b/src/main/java/convex/core/Init.java
@@ -129,11 +129,12 @@ public class Init {
 			// set a staked fund such that the first peer starts with super-majority
 			long stakedFunds = (long) (((i == 0) ? 0.75 : 0.01) * peerFunds);
 
-			// split peer funds between stake and account
-			peers = addPeer(peers, peerKey, stakedFunds);
-
+            // create the peer account first
 			Address peerAddress = Address.create(accts.count());
 			accts = addAccount(accts, peerAddress, peerKey, peerFunds - stakedFunds);
+
+            // split peer funds between stake and account
+			peers = addPeer(peers, peerKey, peerAddress, stakedFunds);
 		}
 
 		// Build globals
@@ -298,8 +299,8 @@ public class Init {
 	}
 
 	private static BlobMap<AccountKey, PeerStatus> addPeer(BlobMap<AccountKey, PeerStatus> peers, AccountKey peerKey,
-			long initialStake) {
-		PeerStatus ps = PeerStatus.create(initialStake, null);
+			Address owner, long initialStake) {
+		PeerStatus ps = PeerStatus.create(owner, initialStake, null);
 		return peers.assoc(peerKey, ps);
 	}
 

--- a/src/main/java/convex/core/data/Keywords.java
+++ b/src/main/java/convex/core/data/Keywords.java
@@ -55,6 +55,7 @@ public class Keywords {
 	public static final Keyword STAKE = Keyword.create("stake");
 	public static final Keyword STAKES = Keyword.create("stakes");
 	public static final Keyword DELEGATED_STAKE = Keyword.create("delegated-stake");
+	public static final Keyword OWNER = Keyword.create("owner");
 
 	public static final Keyword URL = Keyword.create("url");
 

--- a/src/main/java/convex/core/lang/Context.java
+++ b/src/main/java/convex/core/lang/Context.java
@@ -1881,9 +1881,10 @@ public final class Context<T extends ACell> extends AObject {
 		AccountStatus as = getAccountStatus(address);
 
 		AccountKey ak = as.getAccountKey();
-		if (ak == null) return withError(ErrorCodes.STATE,"The peer account cannot must have a public key");
+		if (ak == null) return withError(ErrorCodes.STATE,"The account signing this transaction must have a public key");
 		PeerStatus ps=s.getPeer(ak);
 		if (ps==null) return withError(ErrorCodes.STATE,"Peer does not exist for this account and account key: "+ak.toChecksumHex());
+		if (!ps.getOwner().equals(address)) return withError(ErrorCodes.STATE,"You are not the owner of this peer account");
 
 		Hash lastStateHash = s.getHash();
 		// at the moment only :url is used in the data map

--- a/src/test/java/convex/core/BeliefMergeTest.java
+++ b/src/test/java/convex/core/BeliefMergeTest.java
@@ -63,7 +63,7 @@ public class BeliefMergeTest {
 			KEYS[i] = key;
 			ADDRESSES[i] = address;
 			AccountStatus accStatus = AccountStatus.create((i + 1) * 1000000,key);
-			PeerStatus peerStatus = PeerStatus.create((i + 1) * 100000);
+			PeerStatus peerStatus = PeerStatus.create(address,(i + 1) * 100000);
 			accounts = accounts.conj(accStatus);
 			peers = peers.assoc(key, peerStatus);
 		}
@@ -195,7 +195,7 @@ public class BeliefMergeTest {
 		long INITIAL_BALANCE_RECEIVER = INITIAL_STATE.getBalance(RADDRESS);
 		long TRANSFER_AMOUNT = 100;
 		long TJUICE=Juice.TRANSFER;
-		
+
 		ATransaction trans = Transfer.create(PADDRESS, 1, RADDRESS, TRANSFER_AMOUNT); // note 1 = first sequence number required
 		Peer[] bs3 = proposeTransactions(bs2, PROPOSER, trans);
 		if (ANALYSIS) printAnalysis(bs3, "Make proposal");
@@ -251,7 +251,7 @@ public class BeliefMergeTest {
 	 * round of peers updates is gossipped simultaneously and the results checked at
 	 * each stage To validate correct propagation of the new block across the
 	 * network
-	 * 
+	 *
 	 * @throws BoundsException
 	 */
 	@Test
@@ -277,7 +277,7 @@ public class BeliefMergeTest {
 		Long INITIAL_BALANCE_PROPOSER = INITIAL_STATE.getBalance(PADDRESS);
 		Long INITIAL_BALANCE_RECEIVER = INITIAL_STATE.getBalance(RADDRESS);
 		long TJUICE=Juice.TRANSFER;
-		
+
 		Peer[] bs3 = bs2;
 		for (int i = 0; i < NUM_PEERS; i++) {
 			long TRANSFER_AMOUNT = 100L;
@@ -341,7 +341,7 @@ public class BeliefMergeTest {
 	 * This test creates a set of peers, and one transaction for each peer Each
 	 * round of peers updates is gossipped partially To validate correct propagation
 	 * of the new block across the network
-	 * 
+	 *
 	 * @throws BoundsException
 	 */
 	@Test
@@ -372,7 +372,7 @@ public class BeliefMergeTest {
 		long INITIAL_BALANCE_RECEIVER = INITIAL_STATE.getBalance(RADDRESS);
 		long TJUICE=Juice.TRANSFER*NUM_INITIAL_TRANS;
 
-		
+
 		Peer[] bs3 = bs2;
 		for (int i = 0; i < NUM_PEERS; i++) {
 			// propose initial transactions

--- a/src/test/java/convex/core/data/ParamTestValues.java
+++ b/src/test/java/convex/core/data/ParamTestValues.java
@@ -30,15 +30,15 @@ public class ParamTestValues {
 
 	@Parameterized.Parameters(name = "{index}: {0}")
 	public static Collection<Object[]> dataExamples() {
-		return Arrays.asList(new Object[][] { 
-			{ "Keyword :foo", Samples.FOO }, 
+		return Arrays.asList(new Object[][] {
+			{ "Keyword :foo", Samples.FOO },
 			{ "Empty Vector", Vectors.empty() },
 			{ "Long", CVMLong.ONE },
 			{ "Double", CVMDouble.ONE },
 			{ "Byte", CVMByte.ZERO },
 			{ "Single value map", Maps.of(7, 8) },
 			{ "Account status", AccountStatus.create(1000L,Samples.ACCOUNT_KEY) },
-			{ "Peer status", PeerStatus.create(1000L, Strings.create("http://www.google.com:18888")) },
+			{ "Peer status", PeerStatus.create(Address.create(11), 1000L, Strings.create("http://www.google.com:18888")) },
 			{ "Signed value", SignedData.create(Samples.KEY_PAIR, Strings.create("foo")) },
 			{ "Length 300 vector", Samples.INT_VECTOR_300 } });
 	}
@@ -47,7 +47,7 @@ public class ParamTestValues {
 	public void testCanonical() {
 		assertTrue(data.isCanonical());
 	}
-	
+
 	@Test
 	public void testType() {
 		AType t=data.getType();

--- a/src/test/java/convex/core/data/ParamTestVector.java
+++ b/src/test/java/convex/core/data/ParamTestVector.java
@@ -13,11 +13,12 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import convex.core.exceptions.BadFormatException;
+import convex.core.data.Address;
 import convex.test.Samples;
 
 /**
  * Parameterised test class for a bunch of vectors.
- * 
+ *
  */
 @RunWith(Parameterized.class)
 public class ParamTestVector {
@@ -33,7 +34,7 @@ public class ParamTestVector {
 				.asList(new Object[][] { { "Empty Vector", Vectors.empty() }, { "Single value vector", Vectors.of(7L) },
 						{ "MapEntry vector", MapEntry.of(1L, 2L) }, { "Nested vector", Vectors.of(Vectors.empty()) },
 						{ "Vector with Account status", Vectors.of(AccountStatus.create(1000L,Samples.ACCOUNT_KEY)) },
-						{ "Vector with Peer status", Vectors.of(PeerStatus.create(1000L)) },
+						{ "Vector with Peer status", Vectors.of(PeerStatus.create(Address.create(11), 1000L)) },
 						{ "Length 10 vector", Samples.INT_VECTOR_10 }, { "Length 16 vector", Samples.INT_VECTOR_16 },
 						{ "Length 23 vector", Samples.INT_VECTOR_23 }, { "Length 32 vector", Samples.INT_VECTOR_32 },
 						{ "Length 300 vector", Samples.INT_VECTOR_300 },

--- a/src/test/java/convex/core/lang/CoreTest.java
+++ b/src/test/java/convex/core/lang/CoreTest.java
@@ -2439,9 +2439,9 @@ public class CoreTest extends ACVMTest {
 		AccountKey FIRST_PEER_KEY=Init.KEYPAIRS[0].getAccountKey();
 		String newHostname = "new_hostname:1234";
 		Context<?> ctx=INITIAL_CONTEXT;
-		// make sure we are using the FIRST_PPER adderss
 		ctx=ctx.forkWithAddress(Init.FIRST_PEER);
 		{
+			// make sure we are using the FIRST_PPER adderss
 			ctx=step(ctx,"(set-peer-data {:url \"" + newHostname + "\"})");
 			assertNotError(ctx);
 			assertEquals(newHostname,ctx.getState().getPeer(FIRST_PEER_KEY).getHostname().toString());
@@ -2451,6 +2451,13 @@ public class CoreTest extends ACVMTest {
 			assertEquals(newHostname,ctx.getState().getPeer(FIRST_PEER_KEY).getHostname().toString());
         }
 
+		ctx=ctx.forkWithAddress(Init.VILLAIN);
+		{
+			newHostname = "set-key-hijack";
+			ctx=step(ctx,"(do (set-key 0x" + FIRST_PEER_KEY.toHexString() + ")(set-peer-data {:url \"" + newHostname + "\"}))");
+			assertStateError(ctx);
+		}
+		ctx=ctx.forkWithAddress(Init.FIRST_PEER);
 		assertCastError(step(ctx,"(set-peer-data 0x1234567812345678123456781234567812345678123456781234567812345678)"));
 		assertCastError(step(ctx,"(set-peer-data :bad-key)"));
 		assertArityError(step(ctx,"(set-peer-data {:url \"test\" :bad-key 1234})"));

--- a/src/test/java/convex/examples/PeerCluster.java
+++ b/src/test/java/convex/examples/PeerCluster.java
@@ -13,6 +13,7 @@ import convex.core.data.AString;
 import convex.core.data.AVector;
 import convex.core.data.AccountKey;
 import convex.core.data.AccountStatus;
+import convex.core.data.Address;
 import convex.core.data.BlobMap;
 import convex.core.data.BlobMaps;
 import convex.core.data.Keyword;
@@ -64,9 +65,10 @@ public class PeerCluster {
 			Map<Keyword, Object> config = PEER_CONFIGS.get(i);
 			int port = Utils.toInt(config.get(Keywords.PORT));
 			AString sa = Strings.create("http://localhost"+ port);
-			PeerStatus ps = PeerStatus.create(1000000000, sa);
+			Address address = Address.create(i);
+			PeerStatus ps = PeerStatus.create(address, 1000000000, sa);
 			peers = peers.assoc(peerKey, ps);
-			
+
 			AccountStatus as = AccountStatus.create(1000000000,peerKey);
 			accts = accts.conj(as);
 		}


### PR DESCRIPTION
This resolves the set-key hijack in #185 
At the moment still keep the public key for the peer status map.
Maybe later we should move to using an account address for each peer?

So each PeerStatus has an owner address. 
At the moment it is set by Init, but later this will be set by the `create-peer` for new peers.

Only the address owner can change peer data 
