### PR TITLE
Cli peer sync

### DIFF
--- a/src/main/java/convex/cli/PeerStart.java
+++ b/src/main/java/convex/cli/PeerStart.java
@@ -5,8 +5,10 @@ import java.io.IOException;
 import java.util.logging.Logger;
 
 import convex.cli.peer.PeerManager;
+import convex.core.Belief;
 import convex.core.crypto.AKeyPair;
 import convex.core.data.Address;
+import convex.core.data.SignedData;
 import convex.core.store.AStore;
 import convex.core.store.Stores;
 import etch.EtchStore;
@@ -110,10 +112,8 @@ public class PeerStart implements Runnable {
 			else {
 				store = Stores.getDefaultStore();
 			}
-			System.out.println(String.format("using etch database %s", store.toString()));
-			Stores.setCurrent(store);
-			peerManager.aquireState(keyPair, peerAddress, store, remotePeerHostname);
-			peerManager.launchPeer(keyPair, peerAddress, hostname, port, store, remotePeerHostname);
+			SignedData<Belief> signedBelief = peerManager.aquireLatestBelief(keyPair, peerAddress, store, remotePeerHostname);
+			peerManager.launchPeer(keyPair, peerAddress, hostname, port, store, remotePeerHostname, signedBelief);
 			peerManager.showPeerEvents();
 		} catch (Throwable t) {
 			System.out.println("Unable to launch peer "+t);

--- a/src/main/java/convex/peer/Server.java
+++ b/src/main/java/convex/peer/Server.java
@@ -375,7 +375,6 @@ public class Server implements Closeable {
 			statusPeerList = statusPeerList.assoc(accountKey, buildPeerList.get(key));
 		}
 
-
 		try {
 			if (signedBelief != null) {
 				this.peer = this.peer.mergeBeliefs(signedBelief.getValue());

--- a/src/main/java/convex/peer/Server.java
+++ b/src/main/java/convex/peer/Server.java
@@ -331,7 +331,7 @@ public class Server implements Closeable {
 	}
 
 	@SuppressWarnings("unchecked")
-	public boolean joinNetwork(AKeyPair keyPair, Address address, String remoteHostname) {
+	public boolean joinNetwork(AKeyPair keyPair, Address address, String remoteHostname, SignedData<Belief> signedBelief) {
 		if (remoteHostname == null) {
 			return false;
 		}
@@ -375,9 +375,19 @@ public class Server implements Closeable {
 			statusPeerList = statusPeerList.assoc(accountKey, buildPeerList.get(key));
 		}
 
+
+		try {
+			if (signedBelief != null) {
+				this.peer = this.peer.mergeBeliefs(signedBelief.getValue());
+			}
+		} catch (BadSignatureException | InvalidDataException e) {
+			throw new Error("Cannot merge to latest belief " + e);
+		}
+
 		// now use the remote peer host name list returned from the status call
 		// to connect to the peers
 		connectToPeers(statusPeerList);
+
 		raiseServerChange("join network");
 
 		return true;

--- a/src/main/java/convex/peer/Server.java
+++ b/src/main/java/convex/peer/Server.java
@@ -204,7 +204,6 @@ public class Server implements Closeable {
 
 		} finally {
 			Stores.setCurrent(savedStore);
-			System.out.println("server using store "+ savedStore.toString());
 		}
 	}
 


### PR DESCRIPTION
This is the second part of starting a peer with the other local peers.

This now gets the latest Signed Belief from one of the peers using `acquire` api call and then calls the `peer.mergeBeliefs` to merge the latest belief with the new peer.

The new peer seems to be one step behind until the next state is changed.

We have to do this, because when a peer starts up it only has the initial state, and so cannot process any transactions sent by the new peer keypair, to force a sync of data between peers.