### PR TITLE
Peer close

### DIFF
--- a/src/main/java/convex/cli/Helpers.java
+++ b/src/main/java/convex/cli/Helpers.java
@@ -65,7 +65,6 @@ public class Helpers {
 	 */
 	public static Convex connect(String hostname, int port, Address address, AKeyPair keyPair) {
 		InetSocketAddress host=new InetSocketAddress(hostname, port);
-		System.out.printf("Connecting to peer: %s\n", host);
 		Convex convex;
 		try {
 			convex=Convex.connect(host, address, keyPair);

--- a/src/main/java/convex/cli/peer/PeerManager.java
+++ b/src/main/java/convex/cli/peer/PeerManager.java
@@ -54,6 +54,8 @@ public class PeerManager implements IServerEvent {
 
 	private static final Logger log = Logger.getLogger(PeerManager.class.getName());
 
+	private static final long TRANSACTION_TIMEOUT_MILLIS = 50000;
+
 	protected List<Server> peerServerList = new ArrayList<Server>();
 
 	protected Session session = new Session();
@@ -108,7 +110,7 @@ public class PeerManager implements IServerEvent {
 			try {
 				convex = Convex.connect(remotePeerAddress, address, keyPair, store);
 				Future<Result> cf =  convex.requestStatus();
-				result = cf.get(2000, TimeUnit.MILLISECONDS);
+				result = cf.get(TRANSACTION_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
 				retryCount = 0;
 			} catch (IOException | InterruptedException | ExecutionException | TimeoutException e ) {
 				// raiseServerMessage("unable to connect to remote peer at " + remoteHostname + ". Retrying " + e);
@@ -124,8 +126,7 @@ public class PeerManager implements IServerEvent {
 		Hash beliefHash = RT.ensureHash(values.get(0));
 		Hash stateHash = RT.ensureHash(values.get(1));
 
-		System.out.println("Aquire to " + stateHash.toString() + " / " + beliefHash.toString() + " on db " + store.toString());
-		long timeout = 20000;
+		long timeout = TRANSACTION_TIMEOUT_MILLIS;
 		try {
 			// convex = Convex.connect(localPeerAddress, address, keyPair);
 			long start = Utils.getTimeMillis();

--- a/src/main/java/convex/net/Connection.java
+++ b/src/main/java/convex/net/Connection.java
@@ -136,7 +136,11 @@ public class Connection {
 	 * @throws IOException If connection fails because of any IO problem
 	 * @throws TimeoutException If connection cannot be established within an acceptable time (~5s)
 	 */
-	public static Connection connect(InetSocketAddress hostAddress, Consumer<Message> receiveAction, AStore store) throws IOException {
+	public static Connection connect(
+		InetSocketAddress hostAddress,
+		Consumer<Message> receiveAction,
+		AStore store
+	) throws IOException, TimeoutException {
 		return connect(hostAddress, receiveAction, store, null);
 	}
 
@@ -156,7 +160,7 @@ public class Connection {
 		Consumer<Message> receiveAction,
 		AStore store,
 		AccountKey trustedPeerKey
-	) throws IOException {
+	) throws IOException, TimeoutException {
 		if (store == null) throw new Error("Connection requires a store");
 		SocketChannel clientChannel = SocketChannel.open();
 		clientChannel.configureBlocking(false);

--- a/src/main/java/convex/net/Message.java
+++ b/src/main/java/convex/net/Message.java
@@ -52,6 +52,10 @@ public class Message {
 		return create(null,MessageType.RESPONSE, response);
 	}
 
+	public static Message createGoodBye(SignedData<ACell> peerKey) {
+		return create(null,MessageType.GOODBYE, peerKey);
+	}
+
     public Connection getPeerConnection() {
 		return peerConnection;
 	}

--- a/src/main/java/convex/net/NIOServer.java
+++ b/src/main/java/convex/net/NIOServer.java
@@ -203,7 +203,7 @@ public class NIOServer implements Closeable {
 				log.warning("Interrupted while attempting to add to receive queue");
 				Thread.currentThread().interrupt();
 			}
-		},store);
+		},store,null);
 	}
 
 	protected void selectRead(SelectionKey key) throws IOException {

--- a/src/main/java/convex/peer/API.java
+++ b/src/main/java/convex/peer/API.java
@@ -87,8 +87,8 @@ public class API {
 	 * Launch a set of peers.
 	 *
 	 * @param count Number of peers to launch.
-	 * @param initConfig 
-	 * @param event 
+	 * @param initConfig
+	 * @param event
 	 *
 	 * @return List of Servers launched
 	 *
@@ -123,9 +123,9 @@ public class API {
 
 			try {
 				// Join this Server to the Seer #0
-				serverList.get(i).connectToPeer(genesisServer.getPeerKey(), genesisServer.getHostAddress());
+				serverList.get(i).connectToPeer(genesisServer.getPeerKey(), genesisServer.getHostAddress(), null);
 				// Join server #0 to this server
-				genesisServer.connectToPeer(server.getPeerKey(), server.getHostAddress());
+				genesisServer.connectToPeer(server.getPeerKey(), server.getHostAddress(), null);
 			} catch (IOException e) {
 				log.severe("Failed to connect peers" +e.getMessage());
 			}

--- a/src/main/java/convex/peer/API.java
+++ b/src/main/java/convex/peer/API.java
@@ -127,7 +127,7 @@ public class API {
 				serverList.get(i).connectToPeer(genesisServer.getPeerKey(), genesisServer.getHostAddress(), null);
 				// Join server #0 to this server
 				genesisServer.connectToPeer(server.getPeerKey(), server.getHostAddress(), null);
-			} catch (IOException e) {
+			} catch (IOException | TimeoutException e) {
 				log.severe("Failed to connect peers" +e.getMessage());
 			}
 		}

--- a/src/test/java/convex/peer/MessageReceiverTest.java
+++ b/src/test/java/convex/peer/MessageReceiverTest.java
@@ -29,7 +29,7 @@ public class MessageReceiverTest {
 		// null Queue OK, we aren't queueing with our custom receive action
 		MessageReceiver mr = new MessageReceiver(a -> received.add(a), null);
 		MemoryByteChannel chan = MemoryByteChannel.create(10000);
-		Connection pc = Connection.create(chan, null,Stores.current());
+		Connection pc = Connection.create(chan, null, Stores.current(), null);
 
 		ACell msg1 = RT.cvm("Hello World!");
 		assertTrue(pc.sendData(msg1));


### PR DESCRIPTION
1. On a peer close broadcast the GOODBYE message with a signed peer key
2. Process a GOODBYE message by a peer, if the peer is trusted then close the connection.
3. Set the trusted peer key in the `Connection class` to be `final`, can only be set on a new connection.

I want to stop the possibility of a bad actor just sending out random GOODBYE messages with a signed account key. In theory it is still possible, since the bad actor just needs to copy a previous message and send it out pretending to be the trusted peer.

Not sure how critical this is going to effect the security/stability of the network?

