### PR TITLE
Fix cil local peers

### DIFF
--- a/src/main/java/convex/cli/peer/PeerManager.java
+++ b/src/main/java/convex/cli/peer/PeerManager.java
@@ -75,27 +75,6 @@ public class PeerManager implements IServerEvent {
 
 	public void launchLocalPeers(int count, AInitConfig initConfig) {
 		peerServerList = API.launchLocalPeers(count, initConfig, this);
-
-		// we need to start doing the first invoke on a peer to start all the other
-		// peers to connect and sync with the consensus.
-
-		Server server = peerServerList.get(0);
-		InetSocketAddress hostAddress = server.getHostAddress();
-
-		// TODO Remove this hack once we figure out why Peers need a kick to get started
-		Address peerAddress = initConfig.getUserAddress(0);
-		try {
-			Convex convex = Convex.connect(hostAddress, peerAddress, initConfig.getUserKeyPair(0));
-
-			// send a 'do' to wake up the other peers
-			ACell message = Reader.read("(do)");
-			ATransaction transaction = Invoke.create(peerAddress,-1, message);
-
-			@SuppressWarnings("unused")
-			Future<Result> future = convex.transact(transaction);
-		} catch (IOException | TimeoutException e) {
-			log.severe("cannot connect to the first peer "+e);
-		}
 	}
 
 	public SignedData<Belief> aquireLatestBelief(AKeyPair keyPair, Address address, AStore store, String remotePeerHostname) {

--- a/src/main/java/convex/net/Connection.java
+++ b/src/main/java/convex/net/Connection.java
@@ -717,6 +717,10 @@ public class Connection {
 		return trustedPeerKey;
 	}
 
+	public void setTrustedPeerKey(AccountKey value) {
+		trustedPeerKey = value;
+	}
+
 	public boolean isTrusted() {
 		return trustedPeerKey != null;
 	}

--- a/src/main/java/convex/peer/Server.java
+++ b/src/main/java/convex/peer/Server.java
@@ -959,7 +959,9 @@ public class Server implements Closeable {
 				while (isRunning) {
 
 					// Try belief update
-					maybeUpdateBelief();
+					if (maybeUpdateBelief() ) {
+						raiseServerChange("consensus");
+					}
 
 					// Maybe sleep a bit, wait for some belief updates to accumulate
 					if (hasNewMessages) {

--- a/src/main/java/convex/peer/Server.java
+++ b/src/main/java/convex/peer/Server.java
@@ -89,7 +89,7 @@ public class Server implements Closeable {
 	private static final long SERVER_UPDATE_PAUSE = 1L;
 
 	static final Logger log = Logger.getLogger(Server.class.getName());
-	private static final Level LEVEL_BELIEF = Level.FINER;
+	private static final Level LEVEL_BELIEF = Level.FINEST;
 	static final Level LEVEL_SERVER = Level.FINER;
 	private static final Level LEVEL_DATA = Level.FINEST;
 	private static final Level LEVEL_PARTIAL = Level.FINER;
@@ -363,7 +363,6 @@ public class Server implements Closeable {
 	 */
 	private void processMessage(Message m) {
 		MessageType type = m.getType();
-
 		try {
 			switch (type) {
 			case BELIEF:
@@ -371,6 +370,9 @@ public class Server implements Closeable {
 				break;
 			case CHALLENGE:
 				processChallenge(m);
+				break;
+			case RESPONSE:
+				processResponse(m);
 				break;
 			case COMMAND:
 				break;
@@ -382,9 +384,6 @@ public class Server implements Closeable {
 				break;
 			case QUERY:
 				processQuery(m);
-				break;
-			case RESPONSE:
-				processResponse(m);
 				break;
 			case RESULT:
 				break;
@@ -480,7 +479,7 @@ public class Server implements Closeable {
 		SignedData<AccountKey> signedPeerKey = m.getPayload();
 		AccountKey remotePeerKey = RT.ensureAccountKey(signedPeerKey.getValue());
 		manager.closeConnection(remotePeerKey);
-		raiseServerChange("conection change");
+		raiseServerChange("connection");
 	}
 
 	/**
@@ -744,71 +743,11 @@ public class Server implements Closeable {
 	}
 
 	private void processChallenge(Message m) {
-		try {
-			SignedData<AVector<ACell>> signedData = m.getPayload();
-			if ( signedData == null) {
-				log.log(ConnectionManager.LEVEL_CHALLENGE_RESPONSE, "challenge bad message data sent");
-				return;
-			}
-			AVector<ACell> challengeValues = signedData.getValue();
-
-			if (challengeValues == null || challengeValues.size() != 3) {
-				log.log(ConnectionManager.LEVEL_CHALLENGE_RESPONSE, "challenge data incorrect number of items should be 3 not " + RT.count(challengeValues));
-				return;
-			}
-			Connection pc = m.getPeerConnection();
-			if ( pc == null) {
-				log.log(ConnectionManager.LEVEL_CHALLENGE_RESPONSE, "No remote peer connection from challenge");
-				return;
-			}
-			log.log(ConnectionManager.LEVEL_CHALLENGE_RESPONSE, "Processing challenge request from: " + pc.getRemoteAddress());
-
-
-			// get the token to respond with
-			Hash token = RT.ensureHash(challengeValues.get(0));
-			if (token == null) {
-				log.log(ConnectionManager.LEVEL_CHALLENGE_RESPONSE, "no challenge token provided");
-				return;
-			}
-
-			// check to see if we are both want to connect to the same network
-			Hash networkId = RT.ensureHash(challengeValues.get(1));
-			if (networkId == null) {
-				log.log(ConnectionManager.LEVEL_CHALLENGE_RESPONSE, "challenge data has no networkId");
-				return;
-			}
-			if ( !networkId.equals(peer.getNetworkID())) {
-				log.log(ConnectionManager.LEVEL_CHALLENGE_RESPONSE, "challenge data has incorrect networkId");
-				return;
-			}
-			// check to see if the challenge is for this peer
-			AccountKey toPeer = RT.ensureAccountKey(challengeValues.get(2));
-			if (toPeer == null) {
-				log.log(ConnectionManager.LEVEL_CHALLENGE_RESPONSE, "challenge data has no toPeer address");
-				return;
-			}
-			if ( !toPeer.equals(peer.getPeerKey())) {
-				log.log(ConnectionManager.LEVEL_CHALLENGE_RESPONSE, "challenge data has incorrect addressed peer");
-				return;
-			}
-
-			// get who sent this challenge
-			AccountKey fromPeer = signedData.getAccountKey();
-
-			// send the signed response back
-			AVector<ACell> responseValues = Vectors.of(token, peer.getNetworkID(), fromPeer, signedData.getHash());
-
-			SignedData<ACell> response = peer.sign(responseValues);
-			pc.sendResponse(response);
-
-		} catch (Throwable t) {
-			log.warning("Challenge Error: " + t);
-			// t.printStackTrace();
-		}
+		manager.processChallenge(m, peer);
 	}
 
 	private void processResponse(Message m) {
-		manager.processResponse(m,peer);
+		manager.processResponse(m, peer);
 	}
 
 	private void processQuery(Message m) {

--- a/src/main/java/convex/peer/ServerInformation.java
+++ b/src/main/java/convex/peer/ServerInformation.java
@@ -38,12 +38,12 @@ public class ServerInformation {
 		hostname = server.getHostname();
 		connectionCount = manager.getConnectionCount();
 		trustedConnectionCount = manager.getTrustedConnectionCount();
-		isSynced =  order != null;
+		isSynced =  order != null && peer.getConsensusPoint() > 0;
 		networkID = peer.getNetworkID();
 		consensusPoint = peer.getConsensusPoint();
         isJoined = connectionCount > 1;
 		stateHash = peer.getConsensusState().getHash();
-        beliefHash = peer.getSignedBelief().getHash();
+        beliefHash = peer.getBelief().getHash();
 		blockCount = 0;
 		if (order != null ) {
 			blockCount = order.getBlockCount();


### PR DESCRIPTION
I have fixed the refactoring to work with the cli.local.start
1. added back in the event messages for connection consensus change
2. After the initial connection via api to the peer to get the peer key, reconnect the server to the peer with the message handler assigned to the receive queue, to process messages
3. moved `processChallenge` to the ConnectionManager class

This does not solve an issue I'm having with another peer joining the local cluster. I will raise an issue for this..