### PR TITLE
fixes Sets EMPTY compile error

### DIFF
--- a/src/main/java/convex/core/data/Sets.java
+++ b/src/main/java/convex/core/data/Sets.java
@@ -12,7 +12,7 @@ public class Sets {
 	
 	static final Ref<?>[] EMPTY_ENTRIES = new Ref[0];
 
-	static final SetLeaf<?> EMPTY = new SetLeaf<>(EMPTY_ENTRIES);
+	static final SetLeaf<?> EMPTY = new SetLeaf<>((Ref<SetLeaf>[])EMPTY_ENTRIES);
 	
 	@SuppressWarnings("rawtypes")
 	public static final Ref<SetLeaf> EMPTY_REF = EMPTY.getRef();


### PR DESCRIPTION
fixes compile error

```
convex/src/main/java/convex/core/data/Sets.java:[15,41] cannot infer type arguments for convex.core.data.SetLeaf<>
[ERROR]   reason: cannot infer type-variable(s) T
[ERROR]     (argument mismatch; convex.core.data.Ref<?>[] cannot be converted to convex.core.data.Ref<T>[])
```