### PR TITLE
Fix #152, stringifying chars differently based on context

### DIFF
--- a/src/main/java/convex/core/data/prim/CVMChar.java
+++ b/src/main/java/convex/core/data/prim/CVMChar.java
@@ -60,12 +60,25 @@ public final class CVMChar extends APrimitive {
 
 	@Override
 	public void ednString(StringBuilder sb) {
-		sb.append(value);
+		sb.append(Utils.ednString(value));
 	}
 
 	@Override
 	public void print(StringBuilder sb) {
-		sb.append(value);
+		ednString(sb);
+	}
+
+	/**
+	 * Returns the String representation of this CVMChar.
+	 * 
+	 * Different from {@link #print() print()} which returns a readable representation.
+	 *
+	 * For instance, on CVMChar \a, this methods returns "a" while {@link #print() print()} returns "\a".
+	 */
+	@Override
+	public String toString() {
+		// Usually, primitive types are stringified using `print`. This method 
+		return Character.toString(value);
 	}
 
 	@Override

--- a/src/main/java/convex/core/util/Utils.java
+++ b/src/main/java/convex/core/util/Utils.java
@@ -878,7 +878,7 @@ public class Utils {
 		case '\t':
 			return "\\tab";
 		default:
-			return Character.toString(c);
+			return "\\" + Character.toString(c);
 		}
 	}
 

--- a/src/test/java/convex/core/lang/CoreTest.java
+++ b/src/test/java/convex/core/lang/CoreTest.java
@@ -593,6 +593,15 @@ public class CoreTest extends ACVMTest {
 		assertEquals("nil", evalS("(str nil)"));
 		assertEquals("true", evalS("(str true)"));
 		assertEquals("cafebabe", evalS("(str (blob \"CAFEBABE\"))"));
+
+		// Standalone chars are stringified Java-style whereas chars embedded in a container (eg. in a vector)
+		// must be EDN-style readable representations.
+		// 
+		assertEquals("a", evalS("(str \\a)"));
+		assertEquals("conve x", evalS("(str \\c \\o \\n \"ve\" \\space \\x)"));
+		assertEquals("[\\a \\b (fn [] \\newline) (\\return {\\space \\tab})]",
+					 evalS("(str [\\a \\b (fn [] \\newline) (list \\return {\\space \\tab})])"));
+
 	}
 
 	@Test

--- a/src/test/java/convex/util/UtilsTest.java
+++ b/src/test/java/convex/util/UtilsTest.java
@@ -287,8 +287,13 @@ public class UtilsTest {
 		assertEquals("{1 2}", Utils.ednString(Maps.of(1L, 2L)));
 		assertEquals("#inst \"1970-01-01T00:00:00Z\"", Utils.ednString(Instant.ofEpochMilli(0)));
 
-		assertThrows(Error.class, () -> Utils.ednString(ByteBuffer.allocate(3)));
-
+		// Chars
+		// 
+		assertEquals("\\newline", Utils.ednString('\n'));
+		assertEquals("\\return", Utils.ednString('\r'));
+		assertEquals("\\space", Utils.ednString(' '));
+		assertEquals("\\tab", Utils.ednString('\t'));
+		assertEquals("\\a", Utils.ednString('a'));
 	}
 
 	@Test


### PR DESCRIPTION
Stringifying a standalone CVMChar (eg. `(str \a)`) performs as before
(returns "a"), whereas stringifying CVMChars embedded in a container
(eg. `(str [\newline])`) produces a readable EDN representation (returns
"[\newline]").

Also fixes translating non-escaped chars to EDN. Previously, \a -> "a",
which is incorrect. Now, \a -> "\a".