### PR TITLE
Cli log output

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
 		<jmh.version>1.32</jmh.version>
 		<junit.version>5.7.1</junit.version>
 		<slf4j.version>1.7.30</slf4j.version>
+		<logback.version>1.2.3</logback.version>
 
 		<!--Freeze this for reproducible builds. -->
 		<project.build.outputTimestamp>2020-02-02T00:00:00Z</project.build.outputTimestamp>
@@ -284,12 +285,12 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-core</artifactId>
-			<version>1.2.3</version>
+			<version>${logback.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.2.3</version>
+			<version>${logback.version}</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -273,7 +273,7 @@
 		<dependency>
 		    <groupId>org.slf4j</groupId>
     		<artifactId>slf4j-api</artifactId>
-    		<version>1.7.31</version>
+    		<version>${slf4j.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
@@ -281,6 +281,5 @@
 			<version>${slf4j.version}</version>
 			<scope>test</scope>
 		</dependency>
-
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -281,5 +281,15 @@
 			<version>${slf4j.version}</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-core</artifactId>
+			<version>1.2.3</version>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<version>1.2.3</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/src/main/java/convex/cli/Main.java
+++ b/src/main/java/convex/cli/Main.java
@@ -13,10 +13,10 @@ import convex.core.crypto.AKeyPair;
 import convex.core.crypto.PFXTools;
 import convex.core.data.Address;
 import convex.core.init.AInitConfig;
+
+import ch.qos.logback.classic.Level;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-// import org.slf4j.impl.SimpleLogger;
-// import org.slf4j.simple.SimpleLoggerFactory;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -50,7 +50,7 @@ import picocli.CommandLine.ScopeType;
 
 public class Main implements Runnable {
 
-	private static Logger log;
+	private static Logger log = LoggerFactory.getLogger(Main.class);
 
 
 	private static CommandLine commandLine;
@@ -89,8 +89,8 @@ public class Main implements Runnable {
 
     @Option(names={ "-v", "--verbose"},
 		scope = ScopeType.INHERIT,
-		description="Show more verbose log information.")
-	private boolean verbose;
+		description="Show more verbose log information. You can increase verbosity by using multiple -v or -vvv")
+	private boolean[] verbose = new boolean[0];
 
 
 	@Override
@@ -119,18 +119,15 @@ public class Main implements Runnable {
 			System.err.println("unable to parse arguments " + t);
 		}
 
-		System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "warn");
-		if (verbose) {
-			System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "trace");
-		}
+		ch.qos.logback.classic.Logger parentLogger = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
 
-		Main.log = LoggerFactory.getLogger(Main.class);
-		log.info("starting..");
-		log.trace("trace");
-		log.debug("debug");
-		log.info("info");
-		log.warn("warn");
-		log.error("error");
+		Level[] verboseLevels = {Level.INFO, Level.DEBUG, Level.TRACE, Level.ALL};
+
+		parentLogger.setLevel(Level.WARN);
+		if (verbose.length > 0 && verbose.length <= verboseLevels.length) {
+			parentLogger.setLevel(verboseLevels[verbose.length]);
+			log.info("set level to {}", parentLogger.getLevel());
+		}
 
 		int result = 0;
 		try {

--- a/src/main/java/convex/cli/Main.java
+++ b/src/main/java/convex/cli/Main.java
@@ -8,7 +8,6 @@ import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
 
-
 import convex.api.Convex;
 import convex.core.crypto.AKeyPair;
 import convex.core.crypto.PFXTools;
@@ -16,6 +15,8 @@ import convex.core.data.Address;
 import convex.core.init.AInitConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+// import org.slf4j.impl.SimpleLogger;
+// import org.slf4j.simple.SimpleLoggerFactory;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -49,7 +50,7 @@ import picocli.CommandLine.ScopeType;
 
 public class Main implements Runnable {
 
-	private static final Logger log = LoggerFactory.getLogger(Main.class);
+	private static Logger log;
 
 
 	private static CommandLine commandLine;
@@ -118,23 +119,19 @@ public class Main implements Runnable {
 			System.err.println("unable to parse arguments " + t);
 		}
 
+		System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "warn");
 		if (verbose) {
-		/*
-			Logger root = LoggerFactory.getLogger("");
-			root.setLevel(Level.TRACE);
-			log.info("Set log level TRACE");
-		*/
-		/*
-			Logger root = Logger.getLogger("");
-			Level targetLevel = Level.ALL;
-			root.setLevel(targetLevel);
-			for (Handler handler: root.getHandlers()) {
-				handler.setLevel(targetLevel);
-			}
-			log.log(targetLevel, "Set level ALL");
-		*/
-
+			System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "trace");
 		}
+
+		Main.log = LoggerFactory.getLogger(Main.class);
+		log.info("starting..");
+		log.trace("trace");
+		log.debug("debug");
+		log.info("info");
+		log.warn("warn");
+		log.error("error");
+
 		int result = 0;
 		try {
 			result = commandLine.execute(args);

--- a/src/test/java/convex/cli/CLITest.java
+++ b/src/test/java/convex/cli/CLITest.java
@@ -44,26 +44,26 @@ public class CLITest {
 
 	@Test
 	public void testHelp() {
-		assertCommandLineResult(0, "^Usage: convex \\[-hvV\\] .*", "--help");
-		assertCommandLineResult(0, "^Usage: convex \\[-hvV\\] .*", "-h");
-		assertCommandLineResult(0, "^Usage: convex \\[-hvV\\] .*", "help");
-		assertCommandLineResult(0, "^Usage: convex account \\[-hvV\\] .*", "account", "help");
-		assertCommandLineResult(0, "^Usage: convex account balance \\[-hvV\\] .*", "account",  "balance", "--help");
-		assertCommandLineResult(0, "^Usage: convex account create \\[-fhvV\\] .*", "account",  "create", "--help");
-		assertCommandLineResult(0, "^Usage: convex account information \\[-hvV\\] .*", "account",  "information", "--help");
-		assertCommandLineResult(0, "^Usage: convex account fund \\[-hvV\\] .*", "account",  "fund", "--help");
-		assertCommandLineResult(0, "^Usage: convex key \\[-hvV\\] .*", "key", "help");
-		assertCommandLineResult(0, "^Usage: convex key generate \\[-hvV\\] .*", "key", "generate", "--help");
-		assertCommandLineResult(0, "^Usage: convex key list \\[-hvV\\] .*", "key", "list", "--help");
-		assertCommandLineResult(0, "^Usage: convex peer \\[-hvV\\] .*", "peer", "help");
-		assertCommandLineResult(0, "^Usage: convex peer start \\[-hrvV\\] .*", "peer", "start", "--help");
-		assertCommandLineResult(0, "^Usage: convex local \\[-hvV\\] .*", "local", "--help");
-		assertCommandLineResult(0, "^Usage: convex local start \\[-hvV\\] .*", "local", "start", "--help");
-		assertCommandLineResult(0, "^Usage: convex local gui \\[-hvV\\] .*", "local", "gui", "--help");
-		assertCommandLineResult(0, "^Usage: convex query \\[-hvV\\] .*", "query", "--help");
-		assertCommandLineResult(0, "^Usage: convex status \\[-hvV\\] .*", "status", "--help");
-		assertCommandLineResult(0, "^Usage: convex transaction \\[-hvV\\] .*", "transaction", "--help");
-		assertCommandLineResult(0, "^Usage: convex transaction \\[-hvV\\] .*", "transact", "--help");
+		assertCommandLineResult(0, "^Usage: convex \\[-hVv\\] .*", "--help");
+		assertCommandLineResult(0, "^Usage: convex \\[-hVv\\] .*", "-h");
+		assertCommandLineResult(0, "^Usage: convex \\[-hVv\\] .*", "help");
+		assertCommandLineResult(0, "^Usage: convex account \\[-hVv\\] .*", "account", "help");
+		assertCommandLineResult(0, "^Usage: convex account balance \\[-hVv\\] .*", "account",  "balance", "--help");
+		assertCommandLineResult(0, "^Usage: convex account create \\[-fhVv\\] .*", "account",  "create", "--help");
+		assertCommandLineResult(0, "^Usage: convex account information \\[-hVv\\] .*", "account",  "information", "--help");
+		assertCommandLineResult(0, "^Usage: convex account fund \\[-hVv\\] .*", "account",  "fund", "--help");
+		assertCommandLineResult(0, "^Usage: convex key \\[-hVv\\] .*", "key", "help");
+		assertCommandLineResult(0, "^Usage: convex key generate \\[-hVv\\] .*", "key", "generate", "--help");
+		assertCommandLineResult(0, "^Usage: convex key list \\[-hVv\\] .*", "key", "list", "--help");
+		assertCommandLineResult(0, "^Usage: convex peer \\[-hVv\\] .*", "peer", "help");
+		assertCommandLineResult(0, "^Usage: convex peer start \\[-hrVv\\] .*", "peer", "start", "--help");
+		assertCommandLineResult(0, "^Usage: convex local \\[-hVv\\] .*", "local", "--help");
+		assertCommandLineResult(0, "^Usage: convex local start \\[-hVv\\] .*", "local", "start", "--help");
+		assertCommandLineResult(0, "^Usage: convex local gui \\[-hVv\\] .*", "local", "gui", "--help");
+		assertCommandLineResult(0, "^Usage: convex query \\[-hVv\\] .*", "query", "--help");
+		assertCommandLineResult(0, "^Usage: convex status \\[-hVv\\] .*", "status", "--help");
+		assertCommandLineResult(0, "^Usage: convex transaction \\[-hVv\\] .*", "transaction", "--help");
+		assertCommandLineResult(0, "^Usage: convex transaction \\[-hVv\\] .*", "transact", "--help");
 	}
 
 


### PR DESCRIPTION
adds logging output for the CLI.
The CLI still uses slf4j as the logging mechanism.

I found that changing the log level dynamically during runtime in java is not supported for most loggers.

So the CLI uses logback since the library supports dynamic log level changes..

I had to add the following libraries in the pom.xml:

+ logback-core
+ logback-clasic