### PR TITLE
Fix keypair tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1
         with:
-          java-version: '11.0.5'
+          java-version: '15.0.2'
       - name: Cache Maven packages
         uses: actions/cache@v2
         with:

--- a/convex-core/src/main/java/convex/core/crypto/Ed25519KeyPair.java
+++ b/convex-core/src/main/java/convex/core/crypto/Ed25519KeyPair.java
@@ -322,10 +322,6 @@ public class Ed25519KeyPair extends AKeyPair {
 
 	boolean equals(Ed25519KeyPair other) {
 		if (this.keyPair == null || other.keyPair == null) return false;
-		System.out.println("public key compare: " + this.keyPair.getPublic() +
-			" " +
-			other.keyPair.getPublic()
-		);
 		if (!this.keyPair.getPublic().equals(other.keyPair.getPublic())) return false;
 		// private keys are stored in byte format differently depending on the source of this keypair
 		// so we need to convert the to a standard 32 byte private key and then compare
@@ -333,6 +329,11 @@ public class Ed25519KeyPair extends AKeyPair {
 			KeyFactory keyFactory = KeyFactory.getInstance(ED25519);
 			Key keyThis = keyFactory.translateKey(this.keyPair.getPrivate());
 			Key keyOther = keyFactory.translateKey(other.keyPair.getPrivate());
+			System.out.println("key compare: " + Utils.toHexString(keyThis.getEncoded()) +
+				" " +
+				Utils.toHexString(keyOther.getEncoded())
+			);
+
 			return keyThis.equals(keyOther);
 		} catch ( NoSuchAlgorithmException | InvalidKeyException e ) {
 			// throw new Error(e);

--- a/convex-core/src/main/java/convex/core/crypto/Ed25519KeyPair.java
+++ b/convex-core/src/main/java/convex/core/crypto/Ed25519KeyPair.java
@@ -8,7 +8,6 @@ import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.SecureRandom;
@@ -25,7 +24,6 @@ import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters;
 import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 import convex.core.data.ACell;
 import convex.core.data.AccountKey;
@@ -326,18 +324,14 @@ public class Ed25519KeyPair extends AKeyPair {
 		// private keys are stored in byte format differently depending on the source of this keypair
 		// so we need to convert the to a standard 32 byte private key and then compare
 		try {
-			KeyFactory keyFactory = KeyFactory.getInstance(ED25519, "SunEC");
+			KeyFactory keyFactory = KeyFactory.getInstance(ED25519);
 			Key keyThis = keyFactory.translateKey(this.keyPair.getPrivate());
 			Key keyOther = keyFactory.translateKey(other.keyPair.getPrivate());
-			System.out.println("key compare: " + Utils.toHexString(keyThis.getEncoded()) +
-				" " +
-				Utils.toHexString(keyOther.getEncoded())
-			);
-
 			return keyThis.equals(keyOther);
-		} catch ( NoSuchAlgorithmException | InvalidKeyException | NoSuchProviderException e ) {
+		} catch ( NoSuchAlgorithmException | InvalidKeyException  e ) {
 			// throw new Error(e);
 			// do nothing just return false
+			System.out.println(e);
 		}
 		return false;
 	}

--- a/convex-core/src/main/java/convex/core/crypto/Ed25519KeyPair.java
+++ b/convex-core/src/main/java/convex/core/crypto/Ed25519KeyPair.java
@@ -323,6 +323,7 @@ public class Ed25519KeyPair extends AKeyPair {
 		if (!this.keyPair.getPublic().equals(other.keyPair.getPublic())) return false;
 		// private keys are stored in byte format differently depending on the source of this keypair
 		// so we need to convert the to a standard 32 byte private key and then compare
+		// WARNING: This only works if using java > 15 (not for v11)
 		try {
 			KeyFactory keyFactory = KeyFactory.getInstance(ED25519);
 			Key keyThis = keyFactory.translateKey(this.keyPair.getPrivate());
@@ -331,7 +332,7 @@ public class Ed25519KeyPair extends AKeyPair {
 		} catch ( NoSuchAlgorithmException | InvalidKeyException  e ) {
 			// throw new Error(e);
 			// do nothing just return false
-			System.out.println(e);
+			// System.out.println(e);
 		}
 		return false;
 	}

--- a/convex-core/src/main/java/convex/core/crypto/Ed25519KeyPair.java
+++ b/convex-core/src/main/java/convex/core/crypto/Ed25519KeyPair.java
@@ -12,6 +12,7 @@ import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.SecureRandom;
 import java.security.Signature;
+import java.security.Security;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
@@ -23,6 +24,7 @@ import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters;
 import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 import convex.core.data.ACell;
 import convex.core.data.AccountKey;
@@ -46,6 +48,7 @@ public class Ed25519KeyPair extends AKeyPair {
 	private Ed25519KeyPair(KeyPair kp, AccountKey publicKey) {
 		this.keyPair = kp;
 		this.publicKey=publicKey;
+		Security.addProvider(new BouncyCastleProvider());
 	}
 
 	/**

--- a/convex-core/src/main/java/convex/core/crypto/Ed25519KeyPair.java
+++ b/convex-core/src/main/java/convex/core/crypto/Ed25519KeyPair.java
@@ -8,6 +8,7 @@ import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.SecureRandom;
@@ -48,7 +49,6 @@ public class Ed25519KeyPair extends AKeyPair {
 	private Ed25519KeyPair(KeyPair kp, AccountKey publicKey) {
 		this.keyPair = kp;
 		this.publicKey=publicKey;
-		Security.addProvider(new BouncyCastleProvider());
 	}
 
 	/**
@@ -326,7 +326,7 @@ public class Ed25519KeyPair extends AKeyPair {
 		// private keys are stored in byte format differently depending on the source of this keypair
 		// so we need to convert the to a standard 32 byte private key and then compare
 		try {
-			KeyFactory keyFactory = KeyFactory.getInstance(ED25519);
+			KeyFactory keyFactory = KeyFactory.getInstance(ED25519, "SunEC");
 			Key keyThis = keyFactory.translateKey(this.keyPair.getPrivate());
 			Key keyOther = keyFactory.translateKey(other.keyPair.getPrivate());
 			System.out.println("key compare: " + Utils.toHexString(keyThis.getEncoded()) +
@@ -335,7 +335,7 @@ public class Ed25519KeyPair extends AKeyPair {
 			);
 
 			return keyThis.equals(keyOther);
-		} catch ( NoSuchAlgorithmException | InvalidKeyException e ) {
+		} catch ( NoSuchAlgorithmException | InvalidKeyException | NoSuchProviderException e ) {
 			// throw new Error(e);
 			// do nothing just return false
 		}

--- a/convex-core/src/main/java/convex/core/crypto/Ed25519KeyPair.java
+++ b/convex-core/src/main/java/convex/core/crypto/Ed25519KeyPair.java
@@ -322,6 +322,10 @@ public class Ed25519KeyPair extends AKeyPair {
 
 	boolean equals(Ed25519KeyPair other) {
 		if (this.keyPair == null || other.keyPair == null) return false;
+		System.out.println("public key compare: " + this.keyPair.getAccountKey().toHexString() +
+			" " +
+			other.keyPair.getAccountKey().toHexString()
+		);
 		if (!this.keyPair.getPublic().equals(other.keyPair.getPublic())) return false;
 		// private keys are stored in byte format differently depending on the source of this keypair
 		// so we need to convert the to a standard 32 byte private key and then compare

--- a/convex-core/src/main/java/convex/core/crypto/Ed25519KeyPair.java
+++ b/convex-core/src/main/java/convex/core/crypto/Ed25519KeyPair.java
@@ -322,9 +322,9 @@ public class Ed25519KeyPair extends AKeyPair {
 
 	boolean equals(Ed25519KeyPair other) {
 		if (this.keyPair == null || other.keyPair == null) return false;
-		System.out.println("public key compare: " + this.keyPair.getAccountKey().toHexString() +
+		System.out.println("public key compare: " + this.keyPair.getPublic() +
 			" " +
-			other.keyPair.getAccountKey().toHexString()
+			other.keyPair.getPublic()
 		);
 		if (!this.keyPair.getPublic().equals(other.keyPair.getPublic())) return false;
 		// private keys are stored in byte format differently depending on the source of this keypair

--- a/convex-core/src/test/java/convex/core/crypto/Ed25519Test.java
+++ b/convex-core/src/test/java/convex/core/crypto/Ed25519Test.java
@@ -100,8 +100,8 @@ public class Ed25519Test {
 		AKeyPair kp1=Ed25519KeyPair.createSeeded(1337);
 		AKeyPair kp2=Ed25519KeyPair.createSeeded(1337);
 		AKeyPair kp3=Ed25519KeyPair.createSeeded(13378);
-		assertEquals(kp1,kp2);
-		assertNotEquals(kp2,kp3);
+		assertTrue(kp1.equals(kp2));
+		assertFalse(kp2.equals(kp3));
 	}
 
 	@Test

--- a/convex-core/src/test/java/convex/core/crypto/PEMToolsTest.java
+++ b/convex-core/src/test/java/convex/core/crypto/PEMToolsTest.java
@@ -6,7 +6,6 @@ import java.security.InvalidKeyException;
 import java.security.Key;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
 import java.security.PrivateKey;
 import java.security.SecureRandom;
 import java.security.Security;
@@ -55,14 +54,14 @@ public class PEMToolsTest {
 
 
 		try {
-			KeyFactory keyFactory = KeyFactory.getInstance("Ed25519", "SunEC");
+			KeyFactory keyFactory = KeyFactory.getInstance("Ed25519");
 			Key key1 = keyFactory.translateKey(keyPair.getPrivate());
 			// System.out.println("Key 1 " + Utils.toHexString(key1.getEncoded()));
 			Key key2 = keyFactory.translateKey(importKeyPair.getPrivate());
 			// System.out.println("Key 2 " + Utils.toHexString(key1.getEncoded()));
 			assertTrue(key1.equals(key2));
 
-		} catch ( NoSuchAlgorithmException | InvalidKeyException  | NoSuchProviderException e ) {
+		} catch ( NoSuchAlgorithmException | InvalidKeyException  e ) {
 			throw new Error(e);
 		}
 		/*

--- a/convex-core/src/test/java/convex/core/crypto/PEMToolsTest.java
+++ b/convex-core/src/test/java/convex/core/crypto/PEMToolsTest.java
@@ -8,9 +8,7 @@ import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.SecureRandom;
-import java.security.Security;
 
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.jupiter.api.Test;
 
 import convex.core.data.AString;

--- a/convex-core/src/test/java/convex/core/crypto/PEMToolsTest.java
+++ b/convex-core/src/test/java/convex/core/crypto/PEMToolsTest.java
@@ -6,9 +6,12 @@ import java.security.InvalidKeyException;
 import java.security.Key;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
 import java.security.PrivateKey;
 import java.security.SecureRandom;
+import java.security.Security;
 
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.jupiter.api.Test;
 
 import convex.core.data.AString;
@@ -50,15 +53,16 @@ public class PEMToolsTest {
 		ASignature rightSignature = importKeyPair.sign(data.getHash());
 		assertTrue(leftSignature.equals(rightSignature));
 
+
 		try {
-			KeyFactory keyFactory = KeyFactory.getInstance("Ed25519");
+			KeyFactory keyFactory = KeyFactory.getInstance("Ed25519", "SunEC");
 			Key key1 = keyFactory.translateKey(keyPair.getPrivate());
 			// System.out.println("Key 1 " + Utils.toHexString(key1.getEncoded()));
 			Key key2 = keyFactory.translateKey(importKeyPair.getPrivate());
 			// System.out.println("Key 2 " + Utils.toHexString(key1.getEncoded()));
 			assertTrue(key1.equals(key2));
 
-		} catch ( NoSuchAlgorithmException | InvalidKeyException e ) {
+		} catch ( NoSuchAlgorithmException | InvalidKeyException  | NoSuchProviderException e ) {
 			throw new Error(e);
 		}
 		/*

--- a/convex-core/src/test/java/convex/core/crypto/SignKeyPairTest.java
+++ b/convex-core/src/test/java/convex/core/crypto/SignKeyPairTest.java
@@ -1,7 +1,7 @@
 package convex.core.crypto;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.junit.jupiter.api.Test;
 
@@ -9,10 +9,12 @@ public class SignKeyPairTest {
 
 	@Test
 	public void testSeeded() {
-		assertEquals(AKeyPair.createSeeded(13), AKeyPair.createSeeded(13));
-
-		assertNotEquals(AKeyPair.createSeeded(13), AKeyPair.createSeeded(1337));
+		AKeyPair kp1 = AKeyPair.createSeeded(13);
+		AKeyPair kp2 = AKeyPair.createSeeded(13);
+		assertTrue(kp1.equals(kp2));
+		AKeyPair kp3 = AKeyPair.createSeeded(1337);
+		assertFalse(kp1.equals(kp3) );
 	}
-	
+
 
 }


### PR DESCRIPTION
This fixes the errors that have been occuring on the Ed25519KeyPair tests.
+ changed `assertEqual(kp1, kp2)` to `assertTrue(kp1.equals(kp2))`
+ moved the test action to test against java 15 instead of 11, since the private key conversion does not work in java11

So we may need to move up the minimum java requirement to java15 if we want to keep the Ed25519KeyPair equals on private key values