### PR TITLE
Cli port range

### DIFF
--- a/convex-cli/src/main/java/convex/cli/LocalStart.java
+++ b/convex-cli/src/main/java/convex/cli/LocalStart.java
@@ -47,6 +47,11 @@ public class LocalStart implements Runnable {
 			+ "For example: 0xf0234 or f0234")
 	private String[] keystorePublicKey;
 
+    @Option(names={"--ports"},
+		description="Range or list of ports to assign each peer in the cluster. This can be a multiple of --ports %n"
+			+ "or a single --ports=8081,8082,8083 or --ports=8080-8090")
+	private String[] ports;
+
 	@Override
 	public void run() {
 		Main mainParent = localParent.mainParent;
@@ -102,6 +107,7 @@ public class LocalStart implements Runnable {
 				keyPairList.size()
 			);
 		}
+		int peerPorts[] = mainParent.getPortList(ports, count);
 		log.info("Starting local network with "+count+" peer(s)");
 		peerManager.launchLocalPeers(keyPairList);
 		log.info("Local Peers launched");

--- a/convex-cli/src/main/java/convex/cli/LocalStart.java
+++ b/convex-cli/src/main/java/convex/cli/LocalStart.java
@@ -1,5 +1,6 @@
 package convex.cli;
 
+import java.lang.NumberFormatException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -107,9 +108,21 @@ public class LocalStart implements Runnable {
 				keyPairList.size()
 			);
 		}
-		int peerPorts[] = mainParent.getPortList(ports, count);
+		int peerPorts[] = null;
+		if (ports != null) {
+			try {
+				peerPorts = mainParent.getPortList(ports, count);
+			} catch (NumberFormatException e) {
+				log.warn("cannot convert port number " + e);
+				return;
+			}
+			if (peerPorts.length < count) {
+				log.warn("you need only provided {} ports you need to provide at least {} ports", peerPorts.length, count);
+				return;
+			}
+		}
 		log.info("Starting local network with "+count+" peer(s)");
-		peerManager.launchLocalPeers(keyPairList);
+		peerManager.launchLocalPeers(keyPairList, peerPorts);
 		log.info("Local Peers launched");
 		peerManager.showPeerEvents();
 	}

--- a/convex-cli/src/main/java/convex/cli/Main.java
+++ b/convex-cli/src/main/java/convex/cli/Main.java
@@ -6,6 +6,9 @@ import java.security.KeyStore;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 
 import convex.api.Convex;
 import convex.cli.peer.SessionItem;
@@ -346,6 +349,34 @@ public class Main implements Runnable {
 		} catch (Throwable t) {
 			throw new Error("Cannot save the key store file "+t);
 		}
+	}
+
+	int[] getPortList(String ports[], int count) {
+		Pattern rangePattern = Pattern.compile(("([0-9]+)\\s*-\\s*([0-9]*)"));
+		List<String> portTextList = Helpers.splitArrayParameter(ports);
+		List<Integer> portList = new ArrayList<Integer>();
+		int countLeft = count;
+		for (int index = 0; index < portTextList.size() && countLeft > 0; index ++) {
+			String item = portTextList.get(index);
+			Matcher matcher = rangePattern.matcher(item);
+			if (matcher.matches()) {
+				int portFrom = Integer.parseInt(matcher.group(1));
+				int portTo = portFrom  + count + 1;
+				if (!matcher.group(2).isEmpty()) {
+					portTo = Integer.parseInt(matcher.group(2));
+				}
+				for ( int portIndex = portFrom; portIndex <= portTo && countLeft > 0; portIndex ++, --countLeft ) {
+					portList.add(portIndex);
+				}
+			}
+			else if (item.strip().length() == 0) {
+			}
+			else {
+				portList.add(Integer.parseInt(item));
+				countLeft --;
+			}
+		}
+		return portList.stream().mapToInt(Integer::intValue).toArray();
 	}
 
     void showError(Throwable t) {

--- a/convex-cli/src/main/java/convex/cli/Main.java
+++ b/convex-cli/src/main/java/convex/cli/Main.java
@@ -1,6 +1,7 @@
 package convex.cli;
 
 import java.io.File;
+import java.lang.NumberFormatException;
 import java.net.InetSocketAddress;
 import java.security.KeyStore;
 import java.util.ArrayList;
@@ -351,7 +352,7 @@ public class Main implements Runnable {
 		}
 	}
 
-	int[] getPortList(String ports[], int count) {
+	int[] getPortList(String ports[], int count) throws NumberFormatException {
 		Pattern rangePattern = Pattern.compile(("([0-9]+)\\s*-\\s*([0-9]*)"));
 		List<String> portTextList = Helpers.splitArrayParameter(ports);
 		List<Integer> portList = new ArrayList<Integer>();

--- a/convex-cli/src/main/java/convex/cli/peer/PeerManager.java
+++ b/convex-cli/src/main/java/convex/cli/peer/PeerManager.java
@@ -88,11 +88,11 @@ public class PeerManager implements IServerEvent {
         return new PeerManager(sessionFilename, keyPair, address, store);
 	}
 
-	public void launchLocalPeers(List<AKeyPair> keyPairList) {
+	public void launchLocalPeers(List<AKeyPair> keyPairList, int peerPorts[]) {
 		List<AccountKey> keyList=keyPairList.stream().map(kp->kp.getAccountKey()).collect(Collectors.toList());
 
 		State genesisState=Init.createState(keyList);
-		peerServerList = API.launchLocalPeers(keyPairList,genesisState, this);
+		peerServerList = API.launchLocalPeers(keyPairList,genesisState, peerPorts, this);
 	}
 
 	public List<Hash> getNetworkHashList(String remotePeerHostname) {

--- a/convex-cli/src/test/java/convex/cli/CLIMainTest.java
+++ b/convex-cli/src/test/java/convex/cli/CLIMainTest.java
@@ -1,7 +1,9 @@
 package convex.cli;
 
+import java.lang.NumberFormatException;
 import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.junit.jupiter.api.Test;
 
 public class CLIMainTest {
@@ -41,7 +43,10 @@ public class CLIMainTest {
 		result = mainApp.getPortList(combinedCommaOpenRange, 6);
 		assertArrayEquals(new int[]{80, 100, 101, 102, 103, 104}, result);
 
-
+		assertThrows(NumberFormatException.class, () -> {
+			String badNumberValue[] = {"80,100+,200,300"};
+			mainApp.getPortList(badNumberValue, 6);
+		});
 	}
 
 }

--- a/convex-cli/src/test/java/convex/cli/CLIMainTest.java
+++ b/convex-cli/src/test/java/convex/cli/CLIMainTest.java
@@ -1,0 +1,47 @@
+package convex.cli;
+
+import java.util.List;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import org.junit.jupiter.api.Test;
+
+public class CLIMainTest {
+
+	@Test
+	public void testMainGetPortList() {
+		Main mainApp = new Main();
+		String basicList[] = {"80", "90", "100", "101", "200"};
+		int result[] = mainApp.getPortList(basicList, 4);
+		assertArrayEquals(new int[]{80, 90, 100, 101}, result);
+
+		String commaList[] = {"80,90,100,101,200"};
+		result = mainApp.getPortList(commaList, 4);
+		assertArrayEquals(new int[]{80, 90, 100, 101}, result);
+
+		String closedRange[] = {"100-200"};
+		result = mainApp.getPortList(closedRange, 4);
+		assertArrayEquals(new int[]{100, 101, 102, 103}, result);
+
+		String openRange[] = {"100-"};
+		result = mainApp.getPortList(openRange, 6);
+		assertArrayEquals(new int[]{100, 101, 102, 103, 104, 105}, result);
+
+		String combinedClosedRange[] = {"80", "100-103", "200"};
+		result = mainApp.getPortList(combinedClosedRange, 6);
+		assertArrayEquals(new int[]{80, 100, 101, 102, 103, 200}, result);
+
+		String combinedOpenRange[] = {"80", "100-", "200", "300"};
+		result = mainApp.getPortList(combinedOpenRange, 6);
+		assertArrayEquals(new int[]{80, 100, 101, 102, 103, 104}, result);
+
+		String combinedCommaClosedRange[] = {"80,100-103,200"};
+		result = mainApp.getPortList(combinedCommaClosedRange, 6);
+		assertArrayEquals(new int[]{80, 100, 101, 102, 103, 200}, result);
+
+		String combinedCommaOpenRange[] = {"80,100-,200,300"};
+		result = mainApp.getPortList(combinedCommaOpenRange, 6);
+		assertArrayEquals(new int[]{80, 100, 101, 102, 103, 104}, result);
+
+
+	}
+
+}

--- a/convex-gui/src/main/java/convex/gui/manager/mainpanels/PeersListPanel.java
+++ b/convex-gui/src/main/java/convex/gui/manager/mainpanels/PeersListPanel.java
@@ -46,7 +46,7 @@ public class PeersListPanel extends JPanel {
 
 	public void launchAllPeers(PeerGUI manager) {
 		int N=PeerGUI.KEYPAIRS.size();
-		List<Server> serverList = API.launchLocalPeers(PeerGUI.KEYPAIRS,PeerGUI.genesisState,null,null);
+		List<Server> serverList = API.launchLocalPeers(PeerGUI.KEYPAIRS,PeerGUI.genesisState);
 		for (Server server: serverList) {
 			PeerView peer = new PeerView();
 			peer.peerServer = server;

--- a/convex-gui/src/main/java/convex/gui/manager/mainpanels/PeersListPanel.java
+++ b/convex-gui/src/main/java/convex/gui/manager/mainpanels/PeersListPanel.java
@@ -46,7 +46,7 @@ public class PeersListPanel extends JPanel {
 
 	public void launchAllPeers(PeerGUI manager) {
 		int N=PeerGUI.KEYPAIRS.size();
-		List<Server> serverList = API.launchLocalPeers(PeerGUI.KEYPAIRS,PeerGUI.genesisState,null);
+		List<Server> serverList = API.launchLocalPeers(PeerGUI.KEYPAIRS,PeerGUI.genesisState,null,null);
 		for (Server server: serverList) {
 			PeerView peer = new PeerView();
 			peer.peerServer = server;
@@ -97,7 +97,7 @@ public class PeersListPanel extends JPanel {
 		btnConnect.addActionListener(e -> {
 			String input = JOptionPane.showInputDialog("Enter host address: ", "");
 			if (input==null) return; // no result?
-			
+
 			String[] ss = input.split(":");
 			String host = ss[0].trim();
 			int port = (ss.length > 1) ? Integer.parseInt(ss[1].trim()) : 0;

--- a/convex-peer/src/main/java/convex/peer/API.java
+++ b/convex-peer/src/main/java/convex/peer/API.java
@@ -92,6 +92,21 @@ public class API {
 	 *
 	 * @param keyPairs List of keypairs for peers
 	 * @param genesisState GEnesis state for local network
+	 *
+	 * @return List of Servers launched
+	 *
+	 */
+	public static List<Server> launchLocalPeers(List<AKeyPair> keyPairs, State genesisState) {
+		return launchLocalPeers(keyPairs, genesisState, null, null);
+	}
+	/**
+	 * Launch a local set of peers. Intended mainly for testing / development.
+	 *
+	 * The Peers will have a unique genesis State, i.e. an independent network
+	 *
+	 * @param keyPairs List of keypairs for peers
+	 * @param genesisState GEnesis state for local network
+	 * @param peerPorts Array of ports to use for each peer, if == null then randomly assign port numbers
 	 * @param event Server event handler
 	 *
 	 * @return List of Servers launched

--- a/convex-peer/src/main/java/convex/peer/API.java
+++ b/convex-peer/src/main/java/convex/peer/API.java
@@ -61,12 +61,12 @@ public class API {
 	 */
 	public static Server launchPeer(Map<Keyword, Object> peerConfig, IServerEvent event) {
 		HashMap<Keyword,Object> config=new HashMap<>(peerConfig);
-		
+
 		// State no8t strictly necessarry? Should be possible to restore a Peer from store
 		if (!(config.containsKey(Keywords.STATE)||config.containsKey(Keywords.STORE))) {
 			throw new IllegalArgumentException("Peer launch requires a genesis :state or existing :store in config");
 		}
-		
+
 		if (!config.containsKey(Keywords.KEYPAIR)) throw new IllegalArgumentException("Peer launch requires a "+Keywords.KEYPAIR+" in config");
 
 		try {
@@ -87,7 +87,7 @@ public class API {
 
 	/**
 	 * Launch a local set of peers. Intended mainly for testing / development.
-	 * 
+	 *
 	 * The Peers will have a unique genesis State, i.e. an independent network
 	 *
 	 * @param keyPairs List of keypairs for peers
@@ -97,23 +97,23 @@ public class API {
 	 * @return List of Servers launched
 	 *
 	 */
-	public static List<Server> launchLocalPeers(List<AKeyPair> keyPairs, State genesisState, IServerEvent event) {
+	public static List<Server> launchLocalPeers(List<AKeyPair> keyPairs, State genesisState, int peerPorts[], IServerEvent event) {
 		int count=keyPairs.size();
-		
+
 		List<Server> serverList = new ArrayList<Server>();
 
 		Map<Keyword, Object> config = new HashMap<>();
 
 		// Peer should get a new allocated port
 		config.put(Keywords.PORT, null);
-		
+
 		// Peers should all have the same genesis state
 		config.put(Keywords.STATE, genesisState);
 
 		// TODO maybe have this as an option in the calling parameters?
 		AStore store = Stores.current();
 		config.put(Keywords.STORE, store);
-		
+
 		// Automatically manage Peer connections
 		config.put(Keywords.AUTO_MANAGE, true);
 
@@ -121,6 +121,9 @@ public class API {
 		for (int i = 0; i < count; i++) {
 			AKeyPair keyPair = keyPairs.get(i);
 			config.put(Keywords.KEYPAIR, keyPair);
+			if (peerPorts != null) {
+				config.put(Keywords.PORT, peerPorts[i]);
+			}
 			Server server = API.launchPeer(config, event);
 			serverList.add(server);
 		}
@@ -136,7 +139,7 @@ public class API {
 			// Join each additional Server to the Peer #0
 			ConnectionManager cm=server.getConnectionManager();
 			cm.connectToPeer(genesisServer.getHostAddress());
-			
+
 			// Join server #0 to this server
 			genesisServer.getConnectionManager().connectToPeer(server.getHostAddress());
 			server.setHostname("localhost:"+server.getPort());

--- a/convex-peer/src/test/java/convex/peer/ServerTest.java
+++ b/convex-peer/src/test/java/convex/peer/ServerTest.java
@@ -59,7 +59,7 @@ public class ServerTest {
 	private static final List<Server> SERVERS;
 
 	public static final Convex CONVEX;
-	
+
 	public static final AKeyPair[] KEYPAIRS = new AKeyPair[] {
 			AKeyPair.createSeeded(2),
 			AKeyPair.createSeeded(3),
@@ -70,16 +70,16 @@ public class ServerTest {
 			AKeyPair.createSeeded(17),
 			AKeyPair.createSeeded(19),
 	};
-	
+
 	public static ArrayList<AKeyPair> PEER_KEYPAIRS=(ArrayList<AKeyPair>) Arrays.asList(KEYPAIRS).stream().collect(Collectors.toList());
 	public static ArrayList<AccountKey> PEER_KEYS=(ArrayList<AccountKey>) Arrays.asList(KEYPAIRS).stream().map(kp->kp.getAccountKey()).collect(Collectors.toList());
 
 	public static final AKeyPair FIRST_PEER_KEYPAIR = KEYPAIRS[0];
 	public static final AccountKey FIRST_PEER_KEY = FIRST_PEER_KEYPAIR.getAccountKey();
-	
+
 	public static final AKeyPair HERO_KEYPAIR = KEYPAIRS[0];
 	public static final AKeyPair VILLAIN_KEYPAIR = KEYPAIRS[1];
-	
+
 	public static final AccountKey HERO_KEY = HERO_KEYPAIR.getAccountKey();
 
 	public static final Address HERO;
@@ -91,7 +91,7 @@ public class ServerTest {
 		HERO=Address.create(Init.BASE_FIRST_ADDRESS);
 		VILLAIN=HERO.offset(1);
 
-		SERVERS=API.launchLocalPeers(PEER_KEYPAIRS, s, null);
+		SERVERS=API.launchLocalPeers(PEER_KEYPAIRS, s, null,null);
 		Server server = SERVERS.get(0);
 		synchronized(server) {
 			SERVER=server;

--- a/convex-peer/src/test/java/convex/peer/ServerTest.java
+++ b/convex-peer/src/test/java/convex/peer/ServerTest.java
@@ -91,7 +91,7 @@ public class ServerTest {
 		HERO=Address.create(Init.BASE_FIRST_ADDRESS);
 		VILLAIN=HERO.offset(1);
 
-		SERVERS=API.launchLocalPeers(PEER_KEYPAIRS, s, null,null);
+		SERVERS=API.launchLocalPeers(PEER_KEYPAIRS, s);
 		Server server = SERVERS.get(0);
 		synchronized(server) {
 			SERVER=server;


### PR DESCRIPTION
allow the cli convex.local.start to be assigned a list of port numbers via the --ports option.
This allows for docker integration, so that the local network can be started with a set of predefined list of ports to expose/publish via docker.