### PR TITLE
fix ed25519 equals for java11

### DIFF
--- a/convex
+++ b/convex
@@ -1,4 +1,5 @@
 #!/bin/bash
 
+BASE_PATH=$(dirname $0)
 
-java -jar convex-cli/target/convex-cli-0.7.0-SNAPSHOT-jar-with-dependencies.jar $@
+java -jar $BASE_PATH/convex-cli/target/convex-cli-0.7.0-SNAPSHOT-jar-with-dependencies.jar $@

--- a/convex-core/src/main/java/convex/core/crypto/Ed25519KeyPair.java
+++ b/convex-core/src/main/java/convex/core/crypto/Ed25519KeyPair.java
@@ -149,7 +149,7 @@ public class Ed25519KeyPair extends AKeyPair {
 		Ed25519PublicKeyParameters publicKeyParam = privateKeyParam.generatePublicKey();
 		PublicKey generatedPublicKey = publicKeyFromBytes(publicKeyParam.getEncoded());
 		PrivateKey generatedPrivateKey = privateFromBytes(privateKeyParam.getEncoded());
-		return create(generatedPublicKey, generatedPrivateKey);
+		return create(generatedPublicKey, privateKey);
 	}
 
 	/**
@@ -320,21 +320,9 @@ public class Ed25519KeyPair extends AKeyPair {
 	boolean equals(Ed25519KeyPair other) {
 		if (this.keyPair == null || other.keyPair == null) return false;
 		if (!this.keyPair.getPublic().equals(other.keyPair.getPublic())) return false;
-		// private keys are stored in byte format differently depending on the source of this keypair
-		// so we need to convert the to a standard 32 byte private key and then compare
-		// WARNING: This only works if using java > 15 (not for v11)
-		try {
-			KeyFactory keyFactory = KeyFactory.getInstance(ED25519);
-			Key keyThis = keyFactory.translateKey(this.keyPair.getPrivate());
-			Key keyOther = keyFactory.translateKey(other.keyPair.getPrivate());
-			return keyThis.equals(keyOther);
-		} catch ( NoSuchAlgorithmException | InvalidKeyException  e ) {
-			// throw new Error(e);
-			// do nothing just return false
-			// System.out.println(e);
-		}
-		return false;
+		Blob thisKey = this.getEncodedPrivateKey();
+		Blob otherKey = other.getEncodedPrivateKey();
+		return thisKey.equals(otherKey);
 	}
-
 
 }

--- a/convex-core/src/test/java/convex/core/crypto/PEMToolsTest.java
+++ b/convex-core/src/test/java/convex/core/crypto/PEMToolsTest.java
@@ -12,6 +12,7 @@ import java.security.SecureRandom;
 import org.junit.jupiter.api.Test;
 
 import convex.core.data.AString;
+import convex.core.data.Blob;
 import convex.core.data.Strings;
 import convex.core.util.Utils;
 
@@ -50,24 +51,10 @@ public class PEMToolsTest {
 		ASignature rightSignature = importKeyPair.sign(data.getHash());
 		assertTrue(leftSignature.equals(rightSignature));
 
+        Blob key1 = keyPair.getEncodedPrivateKey();
+		Blob key2 = importKeyPair.getEncodedPrivateKey();
+		assertTrue(key1.equals(key2));
 
-		try {
-			KeyFactory keyFactory = KeyFactory.getInstance("Ed25519");
-			Key key1 = keyFactory.translateKey(keyPair.getPrivate());
-			// System.out.println("Key 1 " + Utils.toHexString(key1.getEncoded()));
-			Key key2 = keyFactory.translateKey(importKeyPair.getPrivate());
-			// System.out.println("Key 2 " + Utils.toHexString(key1.getEncoded()));
-			assertTrue(key1.equals(key2));
-
-		} catch ( NoSuchAlgorithmException | InvalidKeyException  e ) {
-			throw new Error(e);
-		}
-		/*
-		System.out.println("public key 1 " + keyPair.getAccountKey().toHexString());
-		System.out.println("Private key 1 " + Utils.toHexString(keyPair.getPrivate().getEncoded()));
-		System.out.println("public key 2 " + importKeyPair.getAccountKey().toHexString());
-		System.out.println("Private key 2 " + Utils.toHexString(importKeyPair.getPrivate().getEncoded()));
-		*/
 		assertTrue(keyPair.equals(importKeyPair));
 	}
 }


### PR DESCRIPTION
+ fixes the Ed25519KeyPair class equals method to work correctly for java11+
+ added absolute path for the java archive in the convex script file relative to the convex script path