### PR TITLE
add status request sync with missing data fix

### DIFF
--- a/convex-peer/src/main/java/convex/api/Convex.java
+++ b/convex-peer/src/main/java/convex/api/Convex.java
@@ -605,18 +605,14 @@ public class Convex {
 	 *
 	 */
 	public AVector<ACell> requestStatusSync(long timeoutMillis) throws IOException, InterruptedException, ExecutionException, TimeoutException {
-		Future<Result> statusFuture=requestStatus();
 		AVector<ACell> status = null;
 		int retryCount = 10;
-		while (retryCount > 0 ) {
+		Future<Result> statusFuture=requestStatus();
+		while (status == null && retryCount > 0 ) {
 			try {
 				status=statusFuture.get(timeoutMillis,TimeUnit.MILLISECONDS).getValue();
-				if (status != null) {
-					break;
-				}
 			} catch (MissingDataException e) {
-				acquire(e.getMissingHash()).get(timeoutMillis,TimeUnit.MILLISECONDS);
-				statusFuture=requestStatus();
+				status = (AVector<ACell>) acquire(e.getMissingHash()).get(timeoutMillis,TimeUnit.MILLISECONDS);
 			}
 			retryCount -= 1;
 		}

--- a/convex-peer/src/main/java/convex/peer/Server.java
+++ b/convex-peer/src/main/java/convex/peer/Server.java
@@ -245,10 +245,9 @@ public class Server implements Closeable {
 				InetSocketAddress sourceAddr=Utils.toInetSocketAddress(source);
 				Convex convex=Convex.connect(sourceAddr);
 				log.info("Attempting Peer Sync with: "+sourceAddr);
-				Future<Result> statusF=convex.requestStatus();
-				long timeout=establishTimeout();
-				AVector<ACell> status=statusF.get(timeout,TimeUnit.MILLISECONDS).getValue();
-				if (status.count()!=Constants.STATUS_COUNT) {
+				long timeout = establishTimeout();
+				AVector<ACell> status = convex.requestStatusSync(timeout);
+				if (status == null || status.count()!=Constants.STATUS_COUNT) {
 					throw new Error("Bad status message from remote Peer");
 				}
 				Hash beliefHash=RT.ensureHash(status.get(0));


### PR DESCRIPTION
this is a fix for the missing data on status request. I have added a new method called `Convex.statusRequestSync`.
This does a async `statusRequest` and we get a missing data, then call the `acquire` to get the missing status message