### PR TITLE
make build reproducible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,6 +201,11 @@
 					<artifactId>maven-surefire-plugin</artifactId>
 					<version>3.0.0-M4</version>
 				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-jar-plugin</artifactId>
+					<version>3.2.0</version>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 	</build>


### PR DESCRIPTION
the maven-jar-plugin version is the only key missing configuration
remaining issue for reproducible-central is just because reference build is done on Windows, while reproducible-central rebuilds with containers...