### PR TITLE
catch missing exception in peer connection

### DIFF
--- a/convex-peer/src/main/java/convex/net/NIOServer.java
+++ b/convex-peer/src/main/java/convex/net/NIOServer.java
@@ -7,6 +7,7 @@ import java.net.ServerSocket;
 import java.net.SocketException;
 import java.net.StandardSocketOptions;
 import java.nio.channels.ClosedChannelException;
+import java.nio.channels.CancelledKeyException;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
 import java.nio.channels.ServerSocketChannel;
@@ -139,7 +140,11 @@ public class NIOServer implements Closeable {
 							log.warn("Unexpected IOException, canceling key: {}",e);
 							// e.printStackTrace();
 							key.cancel();
-						}
+						} catch (CancelledKeyException e) {
+							log.warn("Connection is not acceptable, canceling key: {}",e);
+							// e.printStackTrace();
+							key.cancel();
+            }
 					}
 					// keys.clear();
 				}


### PR DESCRIPTION
We obviously need to catch the 'CancelledKeyException' within the peer
server  connection loop.  When doing  so network  peers run  much more
stable on Linux hosts.

Signed-off-by: Otto Linnemann <linneman@gmx.de>