### PR TITLE
Add CVX code for an improved CNS

### DIFF
--- a/convex-core/src/main/cvx/convex/lab/cns.cvx
+++ b/convex-core/src/main/cvx/convex/lab/cns.cvx
@@ -1,0 +1,227 @@
+'convex.cns
+
+
+;;;;;;;;;; Initialization
+
+;; Deployer must define:
+;;   `root-controller` -> address of the root controller of the CNS
+;;   `trust`           -> address of the trust library
+
+
+(declare root-controller)
+(declare trust)
+
+
+
+(defn init
+  ^{:callable? true}
+  [root-controller trust-address]
+  (def root-controller
+       root-controller)
+  (def trust
+       trust-address)
+  (undef init)
+  nil)
+
+
+;;;;;;;;;; Preparations
+
+
+(def *records*
+  {})
+
+
+
+(def self
+  *address*)
+
+
+;;;;;;;;;; Private helpers
+
+
+(defn -ensure-level
+  [x f-sym]
+  (when-not (and (address? x)
+                 (callable? x
+                            f-sym))
+    (fail :MISSING-INTERFACE
+          [x f-sym]))
+  x)
+
+
+;;;;;;;;;; Library functions
+
+
+(defn entry->path
+
+  ^{:doc {:description "Returns a CNS path (a vector)"
+          :examples    [{:code "(entry->path 'foo.bar)"}
+                        {:code "(entry->path [\"foo\" \"bar \"])"}]
+          :signature   [{:params [entry]}]}}
+
+  [entry]
+
+  (cond
+    (symbol? entry)
+    (split (str entry)
+           \.)
+    ;;
+    (vector? entry)
+    entry
+    ;;
+    (fail :ARGUMENT
+          nil)))
+
+
+
+(defn get-path
+
+  ^{:doc {:description ["Resolves a CNS entry to a value"
+                        "Returns nil if no value is found."
+                        "Note that some CNS level might also allow nil as a valid value"]
+          :examples    [{:code "(get-path 'foo.bar)"}]
+          :signature   [{:params [entry]}]}}
+
+  [entry]
+
+  (reduce (fn [parent child]
+            (call (-ensure-level parent
+                                 'cns-get-key)
+                  (cns-get-key child)))
+          self
+          (entry->path entry)))
+
+
+
+(defn set-path
+
+ ^{:doc {:description ["Registers a new value or updates an existing one at the given CNS entry."
+                       "Caller must have the necessary permissions for doing so, as determined by the last level in the path."
+                       "Options can be provided should the last level need any."]
+         :examples    [{:code "(set-path 'foo.bar #42)"}
+                       {:code "(set-path 'foo.bar #42 {:some :options})"}]
+         :signature   [{:params [entry value]}
+                       {:params [entry value options]}]}}
+
+ ([entry value]
+  (set-path entry
+            value
+            nil))
+
+ ([entry value options]
+  (let [path (entry->path entry)
+        n    (count path)]
+    (if (zero? n)
+     (fail :ARGUMENT
+           nil)
+     (call (-ensure-level (get-path (slice path
+                                           0
+                                           (dec n)))
+                          'cns-set-key)
+           (cns-set-key (last path)
+                        value
+                        options))))))
+
+
+;;;;;;;;;; CNS interface
+
+
+(defn cns-get-key
+
+  ^{:callable? true}
+
+  [key]
+
+  (get-in *records*
+          [key 0]))
+
+
+(defn -set-key
+  [key value]
+  (def *records*
+       (assoc *records*
+              key
+              [value *caller*])))
+
+
+
+(defn cns-set-key
+
+  ^{:callable? true}
+
+  [key value options]
+
+  (let [record (*records* key)
+        object [*address* key]]
+    (if record
+      (do
+        (when-not (trust/trusted? (second record)
+                                  *caller*
+                                  [:update-key options]
+                                  object)
+          (fail :TRUST.UPDATE-KEY
+                nil))
+        (if (nil? value)
+          (dissoc *records*
+                  key)
+          (-set-key key
+                    value)))
+      (do
+        (when-not (trust/trusted? root-controller
+                                  *caller*
+                                  [:add-key options]
+                                  object)
+          (fail :TRUST.ADD-KEY
+                nil))
+        (-set-key key
+                  value)))
+    value))
+
+
+;;;;;;;;;; Specific callable functions related to trust monitors
+
+(defn set-controller
+
+  ^{:callable? true}
+
+  [key controller]
+
+  (let [record (*records* key)]
+    (when (nil? record)
+      (fail :MISSING-RECORD
+            nil))
+    (let [object [*address* key]]
+      (when-not (or (trust/trusted? root-controller
+                                    *caller*
+                                    :set-controller
+                                    object))
+                    (trust/trusted? (second record)
+                                    *caller*
+                                    :set-controller
+                                    object)
+        (fail :TRUST.SET-CONTROLLER
+              nil)))
+    (def *records*
+         (assoc *records*
+                key
+                (assoc record
+                       1
+                       controller)))
+    nil))
+
+
+(defn set-root-controller
+  
+  ^{:callable? true}
+
+  [controller]
+
+  (when-not (trust/trusted? root-controller
+                            *caller*
+                            :set-root-controller
+                            *address*)
+    (fail :TRUST.SET-ROOT-CONTROLLER
+          nil))
+  (def root-controller
+       controller)
+  nil)

--- a/convex-core/src/test/cvx/test/convex/lab/cns.cvx
+++ b/convex-core/src/test/cvx/test/convex/lab/cns.cvx
@@ -1,0 +1,229 @@
+;;
+;;
+;; Testing `convex.cns`
+;;
+;;
+
+
+($.stream/out! (str $.term/clear.screen
+                    "Testing `convex.cns`"))
+
+
+;;;;;;;;;; Setup
+
+
+(import convex.trust :as trust)
+
+
+(def controller
+     ($.account/zombie))
+
+
+(def backup-controller
+     ($.account/zombie))
+
+
+(def root-controller
+     (deploy `(do
+                ~(trust/build-whitelist {:whitelist [backup-controller
+                                                     controller]})
+                (set-controller ~*address*))))
+
+
+($.file/read "src/main/cvx/convex/lab/cns.cvx")
+
+
+(def cns
+     (deploy (cons 'do
+                   (next $/*result*))))
+
+
+(call cns
+      (init root-controller
+            trust))
+
+
+;;;
+
+
+(defn suite.main
+
+  []
+
+  ($.test/group
+    '(($.test/path.conj 'convex.cns)
+
+
+      ;; Entry -> path
+
+      ($.test/trx '(= [:foo :bar :baz]
+                      (cns/entry->path [:foo :bar :baz]))
+                  {:description "Path left untouched"})
+
+      ($.test/trx '(= ["foo" "bar" "baz"]
+                      (cns/entry->path 'foo.bar.baz))
+                  {:description "Splitting entry"})
+
+      ($.test/fail.code #{:ARGUMENT}
+                        '(cns/entry->path 42)
+                        {:description "Entry must be a symbol or a vector"})
+
+
+      ;; Simple operations
+
+      ($.test/trx '(nil? (cns/get-path 'com))
+                  {:description "No records yet"})
+
+      ($.test/fail.code #{:TRUST.ADD-KEY}
+                        '(cns/set-path 'com
+                                       :fail)
+                        {:description "Unapproved account cannot add a record"})
+
+      ($.test/trx '(nil? (cns/get-path 'com))
+                  {:description "Untrusted account did not add a record"})
+
+      ($.test/trx '(= :value
+                      (eval-as controller
+                               `(~cns/set-path 'com
+                                               :value)))
+                  {:description "Whitelisted account can add top record"})
+
+      ($.test/fail.code #{:TRUST.UPDATE-KEY}
+                        '(cns/set-path 'com
+                                       :fail)
+                        {:description "Unapproved account cannot update the record"})
+
+      ($.test/trx '(= :value
+                      (cns/get-path 'com))
+                  {:description "Unapprovoved account did not update the record"})
+
+
+      ;; Creating a 'com' level
+
+      (defn deploy-level
+        []
+        (deploy '(do
+                   (def *records*
+                        {})
+                   (defn cns-get-key
+                     ^{:callable? true}
+                     [k]
+                     (*records* k))
+                   (defn cns-set-key
+                     ^{:callable? true}
+                     [k v _options]
+                     (def *records*
+                          (assoc *records*
+                                 k
+                                 v))
+                     v))))
+
+      (def com
+           (deploy-level))
+
+      ($.test/trx `(= com
+                      (eval-as controller
+                               `(~cns/set-path 'com
+                                               ~com)))
+                  {:description "Controller can update its key"})
+
+      ($.test/trx '(= com
+                      (cns/get-path 'com))
+                  {:description "Controller did update its key"})
+
+
+      ;; Hierarchical registration and resolution
+
+      (loop [i               0
+             path            ["com"]
+             test-assertion+ []]
+        (if (< i
+               10)
+          (let [level  (deploy-level)
+                path-2 (conj path
+                             i)]
+            (recur (inc i)
+                   path-2
+                   (conj test-assertion+
+                         `($.test/trx '(= ~level
+                                           (cns/set-path ~path-2
+                                                         ~level))
+                                      {:description (str "Deploying sub-level " ~i)})
+                         `($.test/trx '(= ~level
+                                           (cns/get-path ~path-2))
+                                      {:description (str "Sub-level " ~i " retrieved")}))))
+          ($.trx/precat (concat '()
+                                test-assertion+))))
+
+
+      ;; Changing the controller of the 'com' level (with a recovery path)
+
+      ($.test/fail.code #{:TRUST.SET-CONTROLLER}
+                        '(call cns
+                               (set-controller "com"
+                                               :fail))
+                        {:description "Untrusted account cannot change a key controller"})
+
+      ($.test/trx `(= controller
+                      (get-in cns/*records*
+                              ["com" 1]))
+                  {:description "Key controller did not change"})
+
+      ($.test/fail.code #{:MISSING-RECORD}
+                        `(eval-as backup-controller
+                                  '(call ~cns
+                                         (set-controller :inexistent-key
+                                                         42)))
+                        {:description "Cannot change controller of inexistent key"})
+
+      ($.test/trx '(nil? (eval-as controller
+                                  `(call ~cns
+                                         (set-controller "com"
+                                                         :set-by-controller))))
+                  {:description "Original controller can change the controller of its key"})
+
+      ($.test/trx '(= :set-by-controller
+                      (get-in cns/*records*
+                              ["com" 1]))
+                  {:description "Controller changed by original controller"})
+
+      ($.test/trx '(nil? (eval-as backup-controller
+                                  `(call ~cns
+                                         (set-controller "com"
+                                                         :set-by-backup-controller))))
+                  {:description "Controller trusted by root controller can always change the controller of a top key, even when it is botched"})
+
+      ($.test/trx '(= :set-by-backup-controller
+                      (get-in cns/*records*
+                              ["com" 1]))
+                  {:description "Controller changed by backup controller"})
+
+
+      ;; Changing the root controller
+
+      ($.test/fail.code #{:TRUST.SET-ROOT-CONTROLLER}
+                        '(call cns
+                               (set-root-controller :new-root-controller))
+                        {:description "Untrusted account cannot change the root controller"})
+
+      ($.test/trx '(= root-controller
+                      cns/root-controller)
+                  {:description "Root controller left untouched by untrusted account"})
+                        
+      ($.test/trx `(nil? (eval-as backup-controller
+                                  '(call ~cns
+                                         (set-root-controller :new-root-controller))))
+                  {:description "Trusted account can change the root controller"})
+
+      ($.test/trx '(= :new-root-controller
+                      cns/root-controller)
+                  {:description "Trusted account did change the root controller"})
+      )))
+
+             
+
+;;;
+
+
+(suite.main)
+($.test/print "convex.cns")


### PR DESCRIPTION
The new Convex Name Service actor now understand hierarchical paths.
Note that it must be initiated using its self-destructing `init`
function.

When approved, it will entirely remplace `*registry*`.

This commit also contains a full test suite for the Convex Runner.