### PR TITLE
[394] Restore compatibility with Java < 17

### DIFF
--- a/convex-core/src/main/java/etch/Etch.java
+++ b/convex-core/src/main/java/etch/Etch.java
@@ -245,8 +245,8 @@ public class Etch {
 		}
 		int mapIndex=Utils.checkedInt(position/MAX_REGION_SIZE); // 1GB chunks
 
-		ByteBuffer bb=getInternalBuffer(mapIndex).duplicate();
-		MappedByteBuffer mbb=(MappedByteBuffer) bb;
+		MappedByteBuffer mbb=(MappedByteBuffer)((ByteBuffer)getInternalBuffer(mapIndex)).duplicate();
+
 		mbb.position(Utils.checkedInt(position-MAX_REGION_SIZE*(long)mapIndex));
 		return mbb;
 	}


### PR DESCRIPTION
Seems do to the trick, Java < 17 was complaining about `.duplicate` hence the value returned from `getInternalBuffer` must be cast.

Solves #394 