### PR TITLE
Fix bad checksum error

### DIFF
--- a/convex-core/src/main/java/convex/core/data/ABlob.java
+++ b/convex-core/src/main/java/convex/core/data/ABlob.java
@@ -162,7 +162,7 @@ public abstract class ABlob extends ACountable<CVMByte> implements Comparable<AB
 	 */
 	public final Hash computeHash(MessageDigest digest) {
 		updateDigest(digest);
-		return Hash.createFromDigest(digest);
+		return Hash.wrap(digest.digest());
 	}
 
 	protected abstract void updateDigest(MessageDigest digest);

--- a/convex-core/src/main/java/convex/core/data/Hash.java
+++ b/convex-core/src/main/java/convex/core/data/Hash.java
@@ -103,15 +103,6 @@ public class Hash extends AArrayBlob {
 	}
 	
 	/**
-	 * Creates a Hash instance from the given message digest. 
-	 * @param digest MessageDigest instance. Will be reset.
-	 * @return New Hash instance
-	 */
-	public static Hash createFromDigest(MessageDigest digest) {
-		return wrap(digest.digest());
-	}
-	
-	/**
 	 * Get the first 32 bits of this Hash. Used for Java hashCodes
 	 * @return Int representing the first 32 bits
 	 */


### PR DESCRIPTION
Fixes #427

I think I finally figured this one out, and unsurprisingly it's due to a stateful object (`MessageDigest`) being mutated at unexpected times. Specifically, in this method:

https://github.com/Convex-Dev/convex/blob/fbf52a1c5a336fafafb57eec6963c9e0a8af3005/convex-core/src/main/java/convex/core/data/ABlob.java#L163-L166

We're updating the digest, then calling `Hash.createFromDigest` which will return the hash and reset the digest object. This appears fine, but then we have this:

https://github.com/Convex-Dev/convex/blob/fbf52a1c5a336fafafb57eec6963c9e0a8af3005/convex-core/src/main/java/convex/core/data/Hash.java#L50-L53

Those static fields in `Hash` are calling `Hashing.sha3`, which is using the same `MessageDigest`. Static fields are initialized the first time a class is loaded, so if `computeHash` is called for the first time and `Hash` has not yet been loaded, the following sequence with occur:

1. The [sha3Store](https://github.com/Convex-Dev/convex/blob/fbf52a1c5a336fafafb57eec6963c9e0a8af3005/convex-core/src/main/java/convex/core/crypto/Hashing.java#L122-L128) will be derefed for the first time, running its initializer and creating the `MessageDigest` object.
2. `AArrayBlob.updateDigest` is called, updating the internal state of that `MessageDigest`.
3. The `Hash.createFromDigest` call causes the `Hash` class to be loaded, causing its static fields to be initialized. They call `Hashing.sha3`, which also derefs `sha3Store` and returns the exact same `MessageDigest` object (because we're still on the same thread) and uses it to generate the hashes for the static fields.
4. `Hash.createFromDigest` then calls `digest.digest()` but at this point its internal state has been reset.

The fix I chose is just to make the `digest()` call happen before the `Hash` class has a chance to load. We could also fix it by making a special `sha3` method that makes a brand new `MessageDigest` every time it's called. Which do you prefer?