### PR TITLE
Parse ::foo as a keyword, not a symbol

### DIFF
--- a/convex-core/src/main/antlr4/convex/core/lang/reader/antlr/Convex.g4
+++ b/convex-core/src/main/antlr4/convex/core/lang/reader/antlr/Convex.g4
@@ -148,7 +148,7 @@ QUOTING: '\'' | '`' | '~' | '~@';
 
 
 KEYWORD:
-   ':' NAME;
+   ':'+ NAME;
 
 SYMBOL
     : NAME

--- a/convex-core/src/test/java/convex/core/lang/ReaderTest.java
+++ b/convex-core/src/test/java/convex/core/lang/ReaderTest.java
@@ -51,6 +51,8 @@ public class ReaderTest {
 		// : is currently a valid symbol character
 		assertEquals(Keyword.create("foo:bar"), Reader.read(":foo:bar"));
 
+		// keywords can start with more than one colon
+		assertEquals(Keyword.create(":foo"), Reader.read("::foo"));
 	}
 
 	@Test


### PR DESCRIPTION
I noticed that `::foo` was being parsed as a symbol:

```
> (def ::foo "hello")

"hello"

> ::foo

"hello"

> (= 'foo '::foo)

true
```

It'll be a breaking change to fix this later, so it probably should be fixed now. I just adjusted up the antlr file so it parses as a keyword.

This leads me to a few questions:

1. Should this throw an exception (maybe during validation in `Keyword.java`) so this syntax can be used later for namespaced keywords? I think probably so.
2. While we're talking about keywords, should `(keyword "hello world")` throw? It currently returns `:hello world`, just like clojure does, but it will of course fail to read as a keyword later. I wouldn't copy this particular quirk from clojure...