### PR TITLE
Fix cons overload

### DIFF
--- a/convex-core/src/main/java/convex/core/lang/RT.java
+++ b/convex-core/src/main/java/convex/core/lang/RT.java
@@ -1103,7 +1103,7 @@ public class RT {
 	 */
 	public static <T extends ACell> AList<T> cons(T x, T y, T z, ACell xs) {
 		ASequence<T> nxs = RT.sequence(xs);
-		return nxs.cons(y).cons(x).cons(z);
+		return nxs.cons(z).cons(y).cons(x);
 	}
 
 	/**


### PR DESCRIPTION
This overload of the `cons` method adds the args in a weird order that I am guessing is a typo: `y`, `x`, and `z`. It looks like it's supposed to add them back-to-front so they end up as `(x y z)` so I fixed it to do that. This method isn't used anywhere so maybe it should just be deleted?