### PR TITLE
Interactive reads

### DIFF
--- a/convex-core/src/main/antlr4/convex/core/lang/reader/antlr/Convex.g4
+++ b/convex-core/src/main/antlr4/convex/core/lang/reader/antlr/Convex.g4
@@ -203,6 +203,6 @@ fragment
 COMMENT: ';' ~[\r\n]* ;
 
 TRASH
-    : ( WS | COMMENT ) -> channel(HIDDEN)
+    : ( WS | COMMENT ) -> skip
     ;
 

--- a/convex-core/src/main/antlr4/convex/core/lang/reader/antlr/Convex.g4
+++ b/convex-core/src/main/antlr4/convex/core/lang/reader/antlr/Convex.g4
@@ -92,18 +92,10 @@ BOOL : 'true' | 'false' ;
 
 DOUBLE:
   (DIGITS | SIGNED_DIGITS) DOUBLE_TAIL;
-  
-fragment  
-DOUBLE_TAIL:
-  DECIMAL EPART | DECIMAL | EPART;
 
-fragment  
-DECIMAL:
-  '.' DIGITS;
-  
-fragment 
-EPART:
-  [eE] (DIGITS | SIGNED_DIGITS);  
+fragment
+DOUBLE_TAIL:
+  [.eE] [-0-9.eE]*;
 
 DIGITS:
   [0-9]+;
@@ -148,7 +140,7 @@ QUOTING: '\'' | '`' | '~' | '~@';
 
 
 KEYWORD:
-   ':' NAME;
+   ':' NAME?;
 
 SYMBOL
     : NAME

--- a/convex-core/src/main/java/convex/core/lang/Reader.java
+++ b/convex-core/src/main/java/convex/core/lang/Reader.java
@@ -60,7 +60,7 @@ public class Reader {
 	 * @param source Reader instance to get expression from
 	 * @return Parsed form (may be nil)
 	 */
-	public static ACell read(java.io.Reader source) throws IOException {
+	public static ACell read(java.io.PushbackReader source) throws IOException {
 		return AntlrReader.read(source);
 	}
 	

--- a/convex-core/src/main/java/convex/core/lang/Reader.java
+++ b/convex-core/src/main/java/convex/core/lang/Reader.java
@@ -55,12 +55,13 @@ public class Reader {
 	}
 
 	/**
-	 * Parses an expression and returns a form as an Object
+	 * Parses an expression and returns a form as an Object, consuming the
+	 * entire source
 	 * 
 	 * @param source Reader instance to get expression from
 	 * @return Parsed form (may be nil)
 	 */
-	public static ACell read(java.io.PushbackReader source) throws IOException {
+	public static ACell read(java.io.Reader source) throws IOException {
 		return AntlrReader.read(source);
 	}
 	
@@ -74,5 +75,17 @@ public class Reader {
 	public static <R extends ACell> R read(String source) {
 		return (R) AntlrReader.read(source);
 	}
+
+    	/**
+	 * Parses an expression and returns a form as an Object. Leaves
+	 * remaining input on the source.
+	 * 
+	 * @param source PushbackReader instance to get expression from
+	 * @return Parsed form (may be nil)
+	 */
+	public static ACell readOne(java.io.PushbackReader source) throws IOException {
+		return AntlrReader.readOne(source);
+	}
+
 
 }

--- a/convex-core/src/main/java/convex/core/lang/reader/AntlrReader.java
+++ b/convex-core/src/main/java/convex/core/lang/reader/AntlrReader.java
@@ -235,7 +235,11 @@ public class AntlrReader {
 		@Override
 		public void exitDoubleValue(DoubleValueContext ctx) {
 			String s=ctx.getText();
-			push( CVMDouble.parse(s));
+			try {
+				push( CVMDouble.parse(s));
+			} catch (NumberFormatException x) {
+				throw new ParseException("Unparseable double value: "+s,x);
+			}
 		}
 
 		@Override

--- a/convex-core/src/test/java/convex/core/lang/reader/ANTLRTest.java
+++ b/convex-core/src/test/java/convex/core/lang/reader/ANTLRTest.java
@@ -42,6 +42,11 @@ public class ANTLRTest {
 		return (R) AntlrReader.readAll(s);
 	}
 
+    @SuppressWarnings("unchecked")
+	private <R extends ACell> R readOne(String s) {
+		return (R) AntlrReader.readOne(new java.io.PushbackReader(new java.io.StringReader(s)));
+	}
+
 	@Test public void testNil() {
 		assertNull(read("nil"));
 	}
@@ -314,6 +319,15 @@ public class ANTLRTest {
 		assertEquals(dst,a.print().toString());
 		
 		doRoundTripTest(dst); // final value should round trip normally
+	}
+
+    @Test public void testReadOne() {
+        assertEquals(Lists.of(1,2),readOne("(1 2) 3"));
+        assertEquals(Lists.of(1,2),readOne("(1 2)(3 4)"));
+        assertEquals(Lists.of(1,2),readOne("(1 2))))"));
+        assertThrows(ParseException.class,()->readOne(")"));
+        assertThrows(ParseException.class,()->readOne("1.0e0.1234"));
+        assertThrows(ParseException.class,()->readOne(":"));
 	}
 
 


### PR DESCRIPTION
Addresses #438 

I had mainly wanted to be able to upgrade my clojure repl to a convex repl and that has been working well for me. But there could be things I'm missing, and edge cases and implications of this change that I'm still missing. Any feedback is welcome. Below are a few things I'm unsure of

### EOF handling
One thing I'm unsure of is if there should be better EOF handling with this feature. Should there be an EOF exception thrown when a read is attempted on EOF? The following currently just throws a ParseException:
```clojure
(let [r (java.io.PushbackReader. (java.io.StringReader. "(+ 1 2 3)"))]
  [(AntlrReader/readOne r)
   (AntlrReader/readOne r)])
```
Should there be more options for EOF handling, as the [clojure.core/read](https://clojure.github.io/clojure/branch-master/clojure.core-api.html#clojure.core/read) allows?

### Testing 
For now the tests I added are fairly minimal, just checking for things I ran into during development. I have tried out using `readOne` in place of `read` for all the relevant test cases and verified that things work as expected. I could try to refactor the reader tests to do in all appropriate tests as well. Or just copy and paste several other of the `read` tests to a `readOne` version.