### PR TITLE
Add `Etch.getDataLength` method

### DIFF
--- a/convex-core/src/main/java/etch/Etch.java
+++ b/convex-core/src/main/java/etch/Etch.java
@@ -577,6 +577,14 @@ public class Etch {
 		}
 	}
 
+
+	/**
+	 * @return Current data size in bytes
+	 */
+	public long getDataLength() {
+		return dataLength;
+	}
+
 	/**
 	 * Writes the data length field for the Etch file. S
 	 * @throws IOException

--- a/convex-core/src/test/java/etch/api/TestEtch.java
+++ b/convex-core/src/test/java/etch/api/TestEtch.java
@@ -3,6 +3,7 @@ package etch.api;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.Random;
@@ -95,6 +96,7 @@ public class TestEtch {
 		// write the Ref
 		Ref<ACell> r2=etch.write(key, r);
 		assertEquals(key,r2.getHash());
+		assertTrue(etch.getDataLength() > 0);
 		// System.out.println(i + " " +  COUNT);
 	}
 }


### PR DESCRIPTION
As a way of retrieving the "real" Etch size.