### PR TITLE
Turn SignedData into a Record

### DIFF
--- a/convex-core/src/main/java/convex/core/data/ARecord.java
+++ b/convex-core/src/main/java/convex/core/data/ARecord.java
@@ -53,8 +53,8 @@ public abstract class ARecord extends AMap<Keyword,ACell> {
 		// Should already be canonical
 		return this;
 	}
-	
-	@Override public final boolean isCVMValue() {
+
+	@Override public boolean isCVMValue() {
 		return true;
 	}
 	

--- a/convex-core/src/main/java/convex/core/data/Keywords.java
+++ b/convex-core/src/main/java/convex/core/data/Keywords.java
@@ -91,4 +91,7 @@ public class Keywords {
 	public static final Keyword TIMEOUT = Keyword.create("timeout");
 	public static final Keyword EVENT_HOOK = Keyword.create("event-hook");
 	public static final Keyword STATIC = Keyword.create("static");
+	
+	public static final Keyword PUBLIC_KEY = Keyword.create("public-key");
+	public static final Keyword SIGNATURE = Keyword.create("signature");
 }


### PR DESCRIPTION
While `SignedData` is not a CVM value, there is an incentive for making it easier to handle in tools like the Convex Shell.