### PR TITLE
Turn transaction types into records 

### DIFF
--- a/convex-core/src/main/java/convex/core/data/Keywords.java
+++ b/convex-core/src/main/java/convex/core/data/Keywords.java
@@ -94,4 +94,11 @@ public class Keywords {
 	
 	public static final Keyword PUBLIC_KEY = Keyword.create("public-key");
 	public static final Keyword SIGNATURE = Keyword.create("signature");
+
+	public static final Keyword AMOUNT = Keyword.create("amount");
+	public static final Keyword CALL = Keyword.create("call");
+	public static final Keyword COMMAND = Keyword.create("command");
+	public static final Keyword OFFER = Keyword.create("offer");
+	public static final Keyword ORIGIN = Keyword.create("origin");
+	public static final Keyword TARGET = Keyword.create("target");
 }

--- a/convex-core/src/main/java/convex/core/transactions/ATransaction.java
+++ b/convex-core/src/main/java/convex/core/transactions/ATransaction.java
@@ -2,10 +2,12 @@ package convex.core.transactions;
 
 import convex.core.data.ACell;
 import convex.core.data.Address;
+import convex.core.data.ARecord;
 import convex.core.data.Format;
 import convex.core.data.type.AType;
 import convex.core.data.type.Transaction;
 import convex.core.lang.Context;
+import convex.core.lang.impl.RecordFormat;
 
 /**
  * Abstract base class for immutable transactions
@@ -18,11 +20,12 @@ import convex.core.lang.Context;
  * indicating a code error or system integrity issue.
  *
  */
-public abstract class ATransaction extends ACell {
+public abstract class ATransaction extends ARecord {
 	protected final Address origin;
 	protected final long sequence;
 
-	protected ATransaction(Address origin, long sequence) {
+	protected ATransaction(RecordFormat format, Address origin, long sequence) {
+		super(format);
 		if (origin==null) throw new ClassCastException("Null Origin Address for transaction");
 		this.origin=origin;
 		this.sequence = sequence;
@@ -108,11 +111,6 @@ public abstract class ATransaction extends ACell {
 	@Override
 	public boolean isCanonical() {
 		return true;
-	}
-	
-	@Override
-	public ACell toCanonical() {
-		return this;
 	}
 
 }

--- a/convex-core/src/main/java/convex/core/transactions/Invoke.java
+++ b/convex-core/src/main/java/convex/core/transactions/Invoke.java
@@ -66,7 +66,7 @@ public class Invoke extends ATransaction {
 	
 	@Override
 	public int encodeRaw(byte[] bs, int pos) {
-		pos = super.encodeRaw(bs,pos); // nonce, address
+		pos = super.encodeRaw(bs,pos); // origin, sequence
 		pos = Format.write(bs,pos, command);
 		return pos;
 	}
@@ -110,7 +110,7 @@ public class Invoke extends ATransaction {
 
 	@Override
 	public int estimatedEncodingSize() {
-		// tag (1), nonce(<12) and target (33)
+		// tag (1), sequence(<12) and target (33)
 		// plus allowance for Amount
 		return 1 + 12 + Format.MAX_EMBEDDED_LENGTH + Format.MAX_VLC_LONG_LENGTH;
 	}

--- a/convex-core/src/main/java/convex/core/transactions/Invoke.java
+++ b/convex-core/src/main/java/convex/core/transactions/Invoke.java
@@ -5,17 +5,19 @@ import java.nio.ByteBuffer;
 import convex.core.Constants;
 import convex.core.data.ACell;
 import convex.core.data.Address;
-import convex.core.data.BlobBuilder;
 import convex.core.data.Format;
 import convex.core.data.IRefFunction;
+import convex.core.data.Keyword;
+import convex.core.data.Keywords;
 import convex.core.data.Ref;
 import convex.core.data.Tag;
+import convex.core.data.prim.CVMLong;
 import convex.core.exceptions.BadFormatException;
 import convex.core.exceptions.InvalidDataException;
 import convex.core.lang.AOp;
 import convex.core.lang.Context;
-import convex.core.lang.RT;
 import convex.core.lang.Reader;
+import convex.core.lang.impl.RecordFormat;
 import convex.core.util.Utils;
 
 /**
@@ -33,8 +35,11 @@ import convex.core.util.Utils;
 public class Invoke extends ATransaction {
 	protected final ACell command;
 
+	private static final Keyword[] KEYS = new Keyword[] { Keywords.COMMAND, Keywords.ORIGIN, Keywords.SEQUENCE };
+	private static final RecordFormat FORMAT = RecordFormat.of(KEYS);
+
 	protected Invoke(Address address,long sequence, ACell args) {
-		super(address,sequence);
+		super(FORMAT,address,sequence);
 		this.command = args;
 	}
 
@@ -111,20 +116,6 @@ public class Invoke extends ATransaction {
 	}
 
 	@Override
-	public boolean isCanonical() {
-		return true;
-	}
-
-	@Override
-	public boolean print(BlobBuilder sb, long limit) {
-		sb.append("{");
-		sb.append(":invoke ");
-		if (!RT.print(sb, command,limit)) return false;;
-		sb.append('}');
-		return sb.check(limit);
-	}
-
-	@Override
 	public void validateCell() throws InvalidDataException {
 		if (command instanceof AOp) {
 			// OK?
@@ -172,5 +163,27 @@ public class Invoke extends ATransaction {
 	@Override
 	public byte getTag() {
 		return Tag.INVOKE;
+	}
+
+	@Override
+	public ACell get(ACell key) {
+		if (Keywords.COMMAND.equals(key)) return command;
+		if (Keywords.ORIGIN.equals(key)) return origin;
+		if (Keywords.SEQUENCE.equals(key)) return CVMLong.create(sequence);
+
+		return null;
+	}
+
+	@Override
+	public Invoke updateAll(ACell[] newVals) {
+		ACell command = (ACell)newVals[0];
+		Address origin = (Address)newVals[1];
+		long sequence = ((CVMLong)newVals[2]).longValue();
+
+		if (command == this.command && origin == this.origin && sequence == this.sequence) {
+			return this;
+		}
+
+		return new Invoke(origin, sequence, command);
 	}
 }

--- a/convex-core/src/main/java/convex/core/transactions/Transfer.java
+++ b/convex-core/src/main/java/convex/core/transactions/Transfer.java
@@ -30,14 +30,14 @@ public class Transfer extends ATransaction {
 	private static final Keyword[] KEYS = new Keyword[] { Keywords.AMOUNT, Keywords.ORIGIN, Keywords.SEQUENCE, Keywords.TARGET };
 	private static final RecordFormat FORMAT = RecordFormat.of(KEYS);
 
-	protected Transfer(Address address,long sequence, Address target, long amount) {
-		super(FORMAT,address,sequence);
+	protected Transfer(Address origin,long sequence, Address target, long amount) {
+		super(FORMAT,origin,sequence);
 		this.target = target;
 		this.amount = amount;
 	}
 
-	public static Transfer create(Address address,long sequence, Address target, long amount) {
-		return new Transfer(address,sequence, target, amount);
+	public static Transfer create(Address origin,long sequence, Address target, long amount) {
+		return new Transfer(origin,sequence, target, amount);
 	}
 
 
@@ -63,12 +63,12 @@ public class Transfer extends ATransaction {
 	 * @return The Transfer object
 	 */
 	public static Transfer read(ByteBuffer bb) throws BadFormatException {
-		Address address=Address.create(Format.readVLCLong(bb));
+		Address origin=Address.create(Format.readVLCLong(bb));
 		long sequence = Format.readVLCLong(bb);
 		Address target = Address.readRaw(bb);
 		long amount = Format.readVLCLong(bb);
 		if (!RT.isValidAmount(amount)) throw new BadFormatException("Invalid amount: "+amount);
-		return create(address,sequence, target, amount);
+		return create(origin,sequence, target, amount);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/convex-core/src/main/java/convex/core/transactions/Transfer.java
+++ b/convex-core/src/main/java/convex/core/transactions/Transfer.java
@@ -30,14 +30,14 @@ public class Transfer extends ATransaction {
 	private static final Keyword[] KEYS = new Keyword[] { Keywords.AMOUNT, Keywords.ORIGIN, Keywords.SEQUENCE, Keywords.TARGET };
 	private static final RecordFormat FORMAT = RecordFormat.of(KEYS);
 
-	protected Transfer(Address address,long nonce, Address target, long amount) {
-		super(FORMAT,address,nonce);
+	protected Transfer(Address address,long sequence, Address target, long amount) {
+		super(FORMAT,address,sequence);
 		this.target = target;
 		this.amount = amount;
 	}
 
-	public static Transfer create(Address address,long nonce, Address target, long amount) {
-		return new Transfer(address,nonce, target, amount);
+	public static Transfer create(Address address,long sequence, Address target, long amount) {
+		return new Transfer(address,sequence, target, amount);
 	}
 
 
@@ -49,7 +49,7 @@ public class Transfer extends ATransaction {
 
 	@Override
 	public int encodeRaw(byte[] bs, int pos) {
-		pos = super.encodeRaw(bs,pos); // nonce, address
+		pos = super.encodeRaw(bs,pos); // origin, sequence
 		pos = target.encodeRaw(bs,pos);
 		pos = Format.writeVLCLong(bs, pos, amount);
 		return pos;
@@ -64,11 +64,11 @@ public class Transfer extends ATransaction {
 	 */
 	public static Transfer read(ByteBuffer bb) throws BadFormatException {
 		Address address=Address.create(Format.readVLCLong(bb));
-		long nonce = Format.readVLCLong(bb);
+		long sequence = Format.readVLCLong(bb);
 		Address target = Address.readRaw(bb);
 		long amount = Format.readVLCLong(bb);
 		if (!RT.isValidAmount(amount)) throw new BadFormatException("Invalid amount: "+amount);
-		return create(address,nonce, target, amount);
+		return create(address,sequence, target, amount);
 	}
 
 	@SuppressWarnings("unchecked")
@@ -88,7 +88,7 @@ public class Transfer extends ATransaction {
 
 	@Override
 	public int estimatedEncodingSize() {
-		// tag (1), nonce(<12) and target (33)
+		// tag (1), sequence(<12) and target (33)
 		// plus allowance for Amount
 		return 1 + 12 + 33 + Format.MAX_VLC_LONG_LENGTH;
 	}

--- a/convex-core/src/main/java/convex/core/transactions/Transfer.java
+++ b/convex-core/src/main/java/convex/core/transactions/Transfer.java
@@ -6,13 +6,17 @@ import convex.core.Constants;
 import convex.core.data.ACell;
 import convex.core.data.Address;
 import convex.core.data.BlobBuilder;
+import convex.core.data.Keyword;
+import convex.core.data.Keywords;
 import convex.core.data.Format;
 import convex.core.data.Tag;
+import convex.core.data.prim.CVMLong;
 import convex.core.exceptions.BadFormatException;
 import convex.core.exceptions.InvalidDataException;
 import convex.core.lang.Context;
 import convex.core.lang.Juice;
 import convex.core.lang.RT;
+import convex.core.lang.impl.RecordFormat;
 
 /**
  * Transaction class representing a coin Transfer from one account to another
@@ -23,8 +27,11 @@ public class Transfer extends ATransaction {
 	protected final Address target;
 	protected final long amount;
 
+	private static final Keyword[] KEYS = new Keyword[] { Keywords.AMOUNT, Keywords.ORIGIN, Keywords.SEQUENCE, Keywords.TARGET };
+	private static final RecordFormat FORMAT = RecordFormat.of(KEYS);
+
 	protected Transfer(Address address,long nonce, Address target, long amount) {
-		super(address,nonce);
+		super(FORMAT,address,nonce);
 		this.target = target;
 		this.amount = amount;
 	}
@@ -87,22 +94,6 @@ public class Transfer extends ATransaction {
 	}
 
 	@Override
-	public boolean isCanonical() {
-		return true;
-	}
-
-	@Override
-	public boolean print(BlobBuilder bb, long limit) {
-		bb.append("{");
-		bb.append(":transfer-to ");
-		if (!target.print(bb,limit)) return false;
-		bb.append(',');
-		bb.append(":amount "+amount);
-		bb.append('}');
-		return bb.check(limit);
-	}
-
-	@Override
 	public void validateCell() throws InvalidDataException {
 		if ((amount<0)||(amount>Constants.MAX_SUPPLY)) throw new InvalidDataException("Invalid amount", this);
 		if (target == null) throw new InvalidDataException("Null Address", this);
@@ -149,5 +140,30 @@ public class Transfer extends ATransaction {
 	@Override
 	public byte getTag() {
 		return Tag.TRANSFER;
+	}
+
+	@Override
+	public ACell get(ACell key) {
+		if (Keywords.AMOUNT.equals(key)) return CVMLong.create(amount);
+		if (Keywords.ORIGIN.equals(key)) return origin;
+		if (Keywords.SEQUENCE.equals(key)) return CVMLong.create(sequence);
+		if (Keywords.TARGET.equals(key)) return target;
+
+		return null;
+	}
+
+	@Override
+	protected Transfer updateAll(ACell[] newVals) {
+		long amount = ((CVMLong)newVals[0]).longValue();
+		Address origin = (Address)newVals[1];
+		long sequence = ((CVMLong)newVals[2]).longValue();
+		Address target = (Address)newVals[3];
+
+		if (amount == this.amount && origin == this.origin && sequence == this.sequence
+			&& target == this.target) {
+			return this;
+		}
+
+		return new Transfer(origin, sequence, target, amount);
 	}
 }


### PR DESCRIPTION
Mainly about making `ATransaction` an `ARecord` as mentioned previously, so that transactions print full information and are more convenient to handle.

I also took the opportunity to slightly improve naming.