### PR TITLE
Make `Order` a subclass of `ARecord`

### DIFF
--- a/convex-core/src/main/java/convex/core/data/Keywords.java
+++ b/convex-core/src/main/java/convex/core/data/Keywords.java
@@ -101,4 +101,8 @@ public class Keywords {
 	public static final Keyword OFFER = Keyword.create("offer");
 	public static final Keyword ORIGIN = Keyword.create("origin");
 	public static final Keyword TARGET = Keyword.create("target");
+
+	public static final Keyword BLOCKS = Keyword.create("blocks");
+	public static final Keyword CONSENSUS_POINT = Keyword.create("consensus-point");
+	public static final Keyword PROPOSAL_POINT = Keyword.create("proposal-point");
 }

--- a/convex-core/src/test/java/convex/core/data/RecordTest.java
+++ b/convex-core/src/test/java/convex/core/data/RecordTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import convex.core.Belief;
 import convex.core.Block;
 import convex.core.Constants;
+import convex.core.Order;
 import convex.core.Result;
 import convex.core.State;
 import convex.core.data.prim.CVMLong;
@@ -41,7 +42,12 @@ public class RecordTest {
 		
 		doRecordTests(b);
 	}
-	
+
+	@Test
+	public void testOrder() {
+		doRecordTests(Order.create());
+	}
+
 	@Test
 	public void testState() {
 		State s = InitTest.STATE;


### PR DESCRIPTION
Note: Probably the last "recordification", making it more consistent with `Belief`, `Block`, etc, which are already records