### PR TITLE
Make `ASignature` a subclass of `AArrayBlob`

### DIFF
--- a/convex-core/src/main/java/convex/core/crypto/ASignature.java
+++ b/convex-core/src/main/java/convex/core/crypto/ASignature.java
@@ -4,7 +4,6 @@ import java.nio.ByteBuffer;
 
 import convex.core.data.AArrayBlob;
 import convex.core.data.ABlob;
-import convex.core.data.ACell;
 import convex.core.data.AccountKey;
 import convex.core.data.Tag;
 import convex.core.exceptions.BadFormatException;
@@ -13,7 +12,11 @@ import convex.core.util.Utils;
 /**
  * Class representing a cryptographic signature
  */
-public abstract class ASignature extends ACell {
+public abstract class ASignature extends AArrayBlob {
+
+	protected ASignature(byte[] signature) {
+		super(signature, 0, signature.length);
+	} 
 
 	/**
 	 * Checks if the signature is valid for a given message hash
@@ -35,12 +38,6 @@ public abstract class ASignature extends ACell {
 	public static ASignature read(ByteBuffer bb) throws BadFormatException {
 		return Ed25519Signature.read(bb);
 	}
-	
-	/**
-	 * Gets the content of this Signature as a hex string
-	 * @return Hex String representation of Signature
-	 */
-	public abstract String toHexString();
 	
 	/**
 	 * Construct a Signature from a hex string

--- a/convex-core/src/main/java/convex/core/crypto/Ed25519Signature.java
+++ b/convex-core/src/main/java/convex/core/crypto/Ed25519Signature.java
@@ -3,10 +3,9 @@ package convex.core.crypto;
 import java.nio.ByteBuffer;
 
 import convex.core.data.AArrayBlob;
-import convex.core.data.ACell;
 import convex.core.data.AString;
 import convex.core.data.AccountKey;
-import convex.core.data.BlobBuilder;
+import convex.core.data.Blob;
 import convex.core.data.Strings;
 import convex.core.data.Tag;
 import convex.core.exceptions.BadFormatException;
@@ -28,10 +27,9 @@ public class Ed25519Signature extends ASignature {
 	 */
 	public static final Ed25519Signature ZERO = wrap(new byte[SIGNATURE_LENGTH]);
 	
-	private final byte[] signatureBytes;
-	
+
 	private Ed25519Signature(byte[] signature) {
-		this.signatureBytes=signature;
+		super(signature);
 	}
 	
 	/**
@@ -50,7 +48,7 @@ public class Ed25519Signature extends ASignature {
 	}
 	
 	@Override
-	public ACell toCanonical() {
+	public Ed25519Signature toCanonical() {
 		return this;
 	}
 	
@@ -79,16 +77,10 @@ public class Ed25519Signature extends ASignature {
 	
 	@Override
 	public int encodeRaw(byte[] bs, int pos) {
-		System.arraycopy(signatureBytes, 0, bs, pos, SIGNATURE_LENGTH);
+		System.arraycopy(store, 0, bs, pos, SIGNATURE_LENGTH);
 		return pos+SIGNATURE_LENGTH;
 	}
 
-	@Override
-	public boolean print(BlobBuilder bb, long limit) {
-		bb.append("{:signature 0x"+Utils.toHexString(signatureBytes)+"}");
-		return bb.check(limit);
-	}
-	
 	@Override
 	public AString toCVMString(long limit) {
 		if (limit<10) return null;
@@ -111,7 +103,7 @@ public class Ed25519Signature extends ASignature {
 //			Signature verifier = Signature.getInstance("Ed25519");
 //		    verifier.initVerify(publicKey);
 //		    verifier.update(hash.getInternalArray(),hash.getOffset(),Hash.LENGTH);
-//			return verifier.verify(signatureBytes);
+//			return verifier.verify(store);
 //		} catch (SignatureException | InvalidKeyException e) {	
 //			return false;
 //		} catch (NoSuchAlgorithmException e) {
@@ -121,26 +113,22 @@ public class Ed25519Signature extends ASignature {
 
 	@Override
 	public void validateCell() throws InvalidDataException {
-		if (signatureBytes.length!=SIGNATURE_LENGTH) throw new InvalidDataException("Bad signature array length?",this);
+		if (store.length!=SIGNATURE_LENGTH) throw new InvalidDataException("Bad signature array length?",this);
 	}
 
 	@Override
 	public int estimatedEncodingSize() {
 		return 1+SIGNATURE_LENGTH;
 	}
-	
+
 	@Override
-	public int getRefCount() {
-		return 0;
+	public byte[] getBytes() {
+		return store;
 	}
 
 	@Override
-	public String toHexString() {
-		return Utils.toHexString(signatureBytes);
+	public Blob getChunk(long i) {
+		return Blob.create(store).getChunk(i);
 	}
-	
-	@Override
-	public byte[] getBytes() {
-		return signatureBytes;
-	}
+
 }

--- a/convex-core/src/main/java/convex/core/data/AArrayBlob.java
+++ b/convex-core/src/main/java/convex/core/data/AArrayBlob.java
@@ -126,7 +126,7 @@ public abstract class AArrayBlob extends ABlob {
 	 * Encodes this Blob, excluding tag byte (will include count)
 	 */
 	@Override
-	public final int encodeRaw(byte[] bs, int pos) {
+	public int encodeRaw(byte[] bs, int pos) {
 		pos=Format.writeVLCLong(bs, pos, length);
 		return writeToBuffer(bs,pos);
 	}
@@ -326,7 +326,7 @@ public abstract class AArrayBlob extends ABlob {
 	}
 	
 	@Override
-	public final byte getTag() {
+	public byte getTag() {
 		return Tag.BLOB;
 	}
 

--- a/convex-core/src/main/java/convex/core/data/ABlob.java
+++ b/convex-core/src/main/java/convex/core/data/ABlob.java
@@ -65,10 +65,10 @@ public abstract class ABlob extends ACountable<CVMLong> implements Comparable<AB
 	 * Converts this data object to a lowercase hex string representation
 	 * @return Hex String representation
 	 */
-	public final String toHexString() {
+	public String toHexString() {
 		return toHexString(Utils.checkedInt(count())*2);
 	}
-	
+
 	/**
 	 * Converts this data object to a hex string representation of the given length.
 	 * Equivalent to truncating the full String representation.
@@ -421,8 +421,8 @@ public abstract class ABlob extends ACountable<CVMLong> implements Comparable<AB
 	public boolean isRegularBlob() {
 		return true;
 	}
-	
-	@Override public final boolean isCVMValue() {
+
+	@Override public boolean isCVMValue() {
 		return true;
 	}
 


### PR DESCRIPTION
Signatures are conceptually similar to blobs, akin to hashes. Making that relationship explicit makes signatures more convenient to handle in environments such as the Convex Shell.

Note: This one might be more controversial but it should complete my quest of making main user exposed types convenient to use similarly proper "on-chain" types. I've added support for running peers in the Shell (the last missing part) and I don't see any other remaining type to support in that way.