### PR TITLE
Allow persisting peer data under a key

### DIFF
--- a/convex-core/src/main/java/convex/core/data/Keywords.java
+++ b/convex-core/src/main/java/convex/core/data/Keywords.java
@@ -105,4 +105,6 @@ public class Keywords {
 	public static final Keyword BLOCKS = Keyword.create("blocks");
 	public static final Keyword CONSENSUS_POINT = Keyword.create("consensus-point");
 	public static final Keyword PROPOSAL_POINT = Keyword.create("proposal-point");
+
+	public static final Keyword ROOT_KEY = Keyword.create("root-key");
 }

--- a/convex-peer/src/main/java/convex/peer/Server.java
+++ b/convex-peer/src/main/java/convex/peer/Server.java
@@ -27,6 +27,7 @@ import convex.core.Result;
 import convex.core.State;
 import convex.core.crypto.AKeyPair;
 import convex.core.data.ACell;
+import convex.core.data.AMap;
 import convex.core.data.AString;
 import convex.core.data.AVector;
 import convex.core.data.AccountKey;
@@ -36,6 +37,7 @@ import convex.core.data.Format;
 import convex.core.data.Hash;
 import convex.core.data.Keyword;
 import convex.core.data.Keywords;
+import convex.core.data.Maps;
 import convex.core.data.PeerStatus;
 import convex.core.data.Ref;
 import convex.core.data.SignedData;
@@ -129,7 +131,13 @@ public class Server implements Closeable {
 	 */
 	private final AStore store;
 
+	/**
+	 * Configuration
+	 */
+
 	private final HashMap<Keyword, Object> config;
+
+	private final ACell rootKey;
 
 	/**
 	 * Flag for a running server. Setting to false will terminate server threads.
@@ -179,6 +187,8 @@ public class Server implements Closeable {
 	private IServerEvent eventHook = null;
 
 	private Server(HashMap<Keyword, Object> config) throws TimeoutException, IOException {
+
+		this.rootKey = (ACell)config.get(Keywords.ROOT_KEY);
 
 		AStore configStore = (AStore) config.get(Keywords.STORE);
 		this.store = (configStore == null) ? Stores.current() : configStore;
@@ -1122,13 +1132,21 @@ public class Server implements Closeable {
 	 *
 	 * This will overwrite any previously persisted peer data.
 	 */
+	@SuppressWarnings("unchecked")
 	public void persistPeerData() {
 		AStore tempStore = Stores.current();
 		try {
 			Stores.setCurrent(store);
-			ACell peerData = peer.toData();
-			store.setRootData(peerData);
-			log.info( "Stored peer data for Server with hash: {}", peerData.getHash().toHexString());
+			ACell rootData = peer.toData();
+
+			if (rootKey != null) {
+				Ref<AMap<ACell,ACell>> rootRef = store.refForHash(store.getRootHash());
+				AMap<ACell,ACell> currentRootData = (rootRef == null)? Maps.empty() : rootRef.getValue();
+				rootData = currentRootData.assoc(rootKey, rootData);
+			}
+
+			store.setRootData(rootData);
+			log.info( "Stored peer data for Server with hash: {}", rootData.getHash().toHexString());
 		} catch (Throwable e) {
 			log.warn("Failed to persist peer state when closing server: {}" ,e.getMessage());
 		} finally {

--- a/convex-peer/src/main/java/convex/peer/Server.java
+++ b/convex-peer/src/main/java/convex/peer/Server.java
@@ -292,7 +292,7 @@ public class Server implements Closeable {
 				// Restore from storage case
 				try {
 
-					Peer peer = Peer.restorePeer(store, keyPair);
+					Peer peer = Peer.restorePeer(store, keyPair, rootKey);
 					if (peer != null) {
 						log.info("Restored Peer with root data hash: {}",store.getRootHash());
 						return peer;

--- a/convex-peer/src/main/java/convex/peer/Server.java
+++ b/convex-peer/src/main/java/convex/peer/Server.java
@@ -1133,7 +1133,7 @@ public class Server implements Closeable {
 	 * This will overwrite any previously persisted peer data.
 	 */
 	@SuppressWarnings("unchecked")
-	public void persistPeerData() {
+	public boolean persistPeerData() {
 		AStore tempStore = Stores.current();
 		try {
 			Stores.setCurrent(store);
@@ -1147,8 +1147,10 @@ public class Server implements Closeable {
 
 			store.setRootData(rootData);
 			log.info( "Stored peer data for Server with hash: {}", rootData.getHash().toHexString());
+			return true;
 		} catch (Throwable e) {
-			log.warn("Failed to persist peer state when closing server: {}" ,e.getMessage());
+			log.warn("Failed to persist peer state: {}" ,e.getMessage());
+			return false;
 		} finally {
 			Stores.setCurrent(tempStore);
 		}
@@ -1158,11 +1160,7 @@ public class Server implements Closeable {
 	public void close() {
 		// persist peer state if necessary
 		if ((peer != null) && Utils.bool(getConfig().get(Keywords.PERSIST))) {
-			try {
-				persistPeerData();
-			} catch (Throwable t) {
-				log.warn("Exception persisting peer data: {}", t);
-			}
+			persistPeerData();
 		}
 
 		// TODO: not much point signing this?


### PR DESCRIPTION
See commit descriptions for details.
I think we have been overthinking #346 . All that's really needed is allowing the user to provide an optional key if peer data cannot be stored directly at the root.