### PR TITLE
Fix `set-peer-data` failing on non-string URLs

### DIFF
--- a/convex-core/src/main/java/convex/core/lang/Context.java
+++ b/convex-core/src/main/java/convex/core/lang/Context.java
@@ -2074,9 +2074,14 @@ public class Context<T extends ACell> extends AObject {
 		// at the moment only :url is used in the data map
 		for (ACell key: data.keySet()) {
 			if (Keywords.URL.equals((Keyword) key)) {
-				AString url = (AString) data.get(Keywords.URL);
-				PeerStatus updatedPeer=ps.withHostname(url);
-				s=s.withPeer(ak, updatedPeer); // adjust peer
+				ACell url = (ACell)data.get(Keywords.URL);
+				if (url == null || url instanceof AString) {
+					PeerStatus updatedPeer=ps.withHostname((AString)url);
+					s=s.withPeer(ak, updatedPeer); // adjust peer
+				}
+				else {
+					return withArgumentError("URL must be Nil or a String");
+				}
 			}
 			else {
 				return withArityError("invalid key name " + key.toString());

--- a/convex-core/src/test/java/convex/core/lang/CoreTest.java
+++ b/convex-core/src/test/java/convex/core/lang/CoreTest.java
@@ -2928,6 +2928,8 @@ public class CoreTest extends ACVMTest {
 			assertEquals(newHostname,ctx.getState().getPeer(InitTest.FIRST_PEER_KEY).getHostname().toString());
         }
 
+		assertArgumentError(step(ctx, "(set-peer-data peer-key {:url :fail})"));
+
 		// Try to hijack with an account that isn't the first Peer
 		ctx=ctx.forkWithAddress(HERO.offset(2));
 		{


### PR DESCRIPTION
`Context` would fail with a class cast exception since it was not validating that the given URL was indeed a string.