### PR TITLE
Fix ordering length reported in peer status

### DIFF
--- a/convex-peer/src/main/java/convex/peer/Server.java
+++ b/convex-peer/src/main/java/convex/peer/Server.java
@@ -953,7 +953,7 @@ public class Server implements Closeable {
 		Order order=peer.getPeerOrder();
 		CVMLong cp = CVMLong.create(order.getConsensusPoint()) ;
 		CVMLong pp = CVMLong.create(order.getProposalPoint()) ;
-		CVMLong op = CVMLong.create(order.count()) ;
+		CVMLong op = CVMLong.create(order.getBlockCount()) ;
 
 		AVector<ACell> reply=Vectors.of(beliefHash,statesHash,genesisHash,peerKey,consensusHash, cp,pp,op);
 		return reply;


### PR DESCRIPTION
The reported value was the number of keys in the ordering (as a record) instead of the number of blocks.