### PR TITLE
Allow setting juice limit on `Context`

### DIFF
--- a/convex-core/src/main/java/convex/core/lang/Context.java
+++ b/convex-core/src/main/java/convex/core/lang/Context.java
@@ -489,7 +489,8 @@ public class Context extends AObject {
 	 * @return true if juice is sufficient, false otherwise.
 	 */
 	public boolean checkJuice(long gulp) {
-		return (juice+gulp<=juiceLimit);
+		long juiceUsed = juice + gulp;
+		return (juiceUsed >= 0 && juiceUsed <= juiceLimit);
 	}
 
 	/**
@@ -1401,6 +1402,11 @@ public class Context extends AObject {
 
 	public Context withJuice(long newJuice) {
 		juice=newJuice;
+		return this;
+	}
+
+	public Context withJuiceLimit(long newJuiceLimit) {
+		juiceLimit = newJuiceLimit;
 		return this;
 	}
 


### PR DESCRIPTION
The default limit is way to small for tools like the Convex Shell.