### PR TITLE
RenameSuggestion

### DIFF
--- a/convex-cli/src/main/java/convex/cli/peer/PeerManager.java
+++ b/convex-cli/src/main/java/convex/cli/peer/PeerManager.java
@@ -119,7 +119,7 @@ public class PeerManager {
 		return hashList;
 	}
 
-	public State aquireState(String remotePeerHostname, Hash stateHash) {
+	public State acquireState(String remotePeerHostname, Hash stateHash) {
 		InetSocketAddress remotePeerAddress = Utils.toInetSocketAddress(remotePeerHostname);
 		Convex convex = null;
 		State state = null;
@@ -134,7 +134,7 @@ public class PeerManager {
 		return state;
 
 	}
-	public SignedData<Belief> aquireBelief(String remotePeerHostname, Hash beliefHash) {
+	public SignedData<Belief> acquireBelief(String remotePeerHostname, Hash beliefHash) {
 		// sync the etch db with the network state
 		Convex convex = null;
 		SignedData<Belief> signedBelief = null;


### PR DESCRIPTION
### Renaming Suggestion of Method Names to Make Them More Descriptive
---
**Description**
---

We have developed a tool (**NameSpotter**) for identifying non-descriptive method names, and using this tool we find several non-descriptive method names in your repository:
```java
/* Non-descriptive Method Name in convex-cli/src/main/java/convex/cli/peer/PeerManager.java */
public State aquireState(String remotePeerHostname, Hash stateHash) {
		InetSocketAddress remotePeerAddress = Utils.toInetSocketAddress(remotePeerHostname);
		Convex convex = null;
		State state = null;
		try {
			convex = Convex.connect(remotePeerAddress, address, keyPair);
			Future<State> bf = convex.acquire(stateHash, store);
			state = bf.get(TRANSACTION_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
			convex.close();
		} catch (IOException | InterruptedException | ExecutionException | TimeoutException e) {
			throw new Error("cannot aquire network state: " + e);
		}
		return state;

	}
public SignedData<Belief> aquireBelief(String remotePeerHostname, Hash beliefHash) {
		// sync the etch db with the network state
		Convex convex = null;
		SignedData<Belief> signedBelief = null;
		InetSocketAddress remotePeerAddress = Utils.toInetSocketAddress(remotePeerHostname);
		try {
			convex = Convex.connect(remotePeerAddress, address, keyPair);
			Future<SignedData<Belief>> cf = convex.acquire(beliefHash, store);
			signedBelief = cf.get(TRANSACTION_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
			convex.close();
		} catch (IOException | InterruptedException | ExecutionException | TimeoutException e) {
			throw new Error("cannot acquire belief: " + e);
		}

		return signedBelief;
	}
```
We considered "aquireState" and "aquireBelief" as non-descriptive because they contain a typo (i.e., aquire should be acquire).

We have corrected them and commited a pull request.



Do you agree with the judgment? 

- If not, could you please leave your valuable opinion?

- If you do agree, the relevant modification has been submitted as a PR, and thanks for your precious time to consider it.