### PR TITLE
Correct port number in example

### DIFF
--- a/convex-cli/src/docs/asciidoc/index.adoc
+++ b/convex-cli/src/docs/asciidoc/index.adoc
@@ -487,7 +487,7 @@ Remember to add the `0x` at the front of the key value, when using a public key 
 
 If the peer has been setup correctly on https://convex.world[convex.world], so you can now start your peer, using the following example command:
 
-    ./convex peer start --public-key=dfbb22 --password=my-password --address=<address> --port=80888 --url=<my-ip>:8088 --peer=convex.world:18888
+    ./convex peer start --public-key=dfbb22 --password=my-password --address=<address> --port=8088 --url=<my-ip>:8088 --peer=convex.world:18888
 
 Where:
 


### PR DESCRIPTION
The documentation uses two different local ports as an example: 8088 and 80888 ([see link](https://convex-dev.github.io/convex/convex-cli/#_starting_the_peer_with_convex_world)). I'm assuming this is a typo. Although this could well be the case if the local process is proxied by another process, I think in standard setups this port would be equal in both cases.
