### PR TITLE
Rollback ./convex to previous version

### DIFF
--- a/convex
+++ b/convex
@@ -1,1 +1,8 @@
-#!/bin/bashBASE_PATH=$(dirname $0)JAR_NAME=`ls -1 $BASE_PATH/convex-cli/target/convex-cli.jar`# echo "using: $JAR_NAME"java -jar $JAR_NAME $@
+#!/bin/bash
+
+BASE_PATH=$(dirname $0)
+JAR_NAME=`ls -1 $BASE_PATH/convex-cli/target/convex-cli.jar`
+
+# echo "using: $JAR_NAME"
+
+java -jar $JAR_NAME $@


### PR DESCRIPTION
This rolls back `./convex` to a previous version with correct line endings. 

The current version gives:

```
./convex
zsh: ./convex: bad interpreter: /bin/bash^M^MBASE_PATH=$(dirname $0)^MJAR_NAME=`ls -1 $BASE_PATH/convex-cli/target/convex-cli.jar`^M^M# echo "using: $JAR_NAME"^M^Mja: no such file or directory
```