### PR TITLE
Fix update and update-in for higher arities

### DIFF
--- a/convex-core/src/main/cvx/convex/core/core.cvx
+++ b/convex-core/src/main/cvx/convex/core/core.cvx
@@ -691,7 +691,7 @@
    ([m k f x]
 	 (assoc m k (f (get m k) x)))
    ([m k f x & more]
-	 (assoc m k (apply f (get m k) more))))
+	 (assoc m k (apply f (get m k) x more))))
  
  (defn update-in
 	^{:doc {:description "Update a value in a nested associative data structure by applying a function."
@@ -701,8 +701,8 @@
 	 (assoc-in m ks (f (get-in m ks))))
    ([m ks f x]
 	 (assoc-in m ks (f (get-in m ks) x)))
-   ([m k f x & more]
-	 (assoc-in m ks (apply f (get-in m ks) more))))
+   ([m ks f x & more]
+	 (assoc-in m ks (apply f (get-in m ks) x more))))
  
  (defn dissoc-in
 	^{:doc {:description "Dissocs from a nested associative data structure. If a nested result is empty? dissoc it as well."

--- a/convex-core/src/test/java/convex/core/lang/CoreTest.java
+++ b/convex-core/src/test/java/convex/core/lang/CoreTest.java
@@ -1421,6 +1421,10 @@ public class CoreTest extends ACVMTest {
 
 		assertEquals(Vectors.of(1,2,3),eval("(update [1 2 3] 1 identity)"));
 
+		assertEquals(Vectors.of(0,2,0),eval("(update [0 1 0] 1 + 1)"));
+		assertEquals(Vectors.of(0,4,0),eval("(update [0 1 0] 1 + 1 2)"));
+		assertEquals(Vectors.of(0,46,0),eval("(apply update [0 1 0] 1 + [1 2 3 4 5 6 7 8 9])"));
+
 		// nil works as empty map 
 		assertEquals(Maps.of(2,Sets.of(2,3)),eval("(update nil 2 union #{2,3})"));
 		
@@ -1444,6 +1448,10 @@ public class CoreTest extends ACVMTest {
 
 		assertEquals(Vectors.of(1,2,3),eval("(update-in [1 2 3] [1] identity)"));
 
+		assertEquals(Vectors.of(0,2,0),eval("(update-in [0 1 0] [1] + 1)"));
+		assertEquals(Vectors.of(0,4,0),eval("(update-in [0 1 0] [1] + 1 2)"));
+		assertEquals(Vectors.of(0,46,0),eval("(apply update-in [0 1 0] [1] + [1 2 3 4 5 6 7 8 9])"));
+		
 		// nil works as empty map 
 		assertEquals(Maps.of(2,Sets.of(2,3)),eval("(update-in nil [2] union #{2,3})"));
 		


### PR DESCRIPTION
Fixes #533 

Added unit tests and fixed the implementation.

The GenesisTest is now failing. I guess this is expected when changing core resources?

```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.045 s <<< FAILURE! -- in convex.core.init.GenesisTest
[ERROR] convex.core.init.GenesisTest.testGenesis -- Time elapsed: 0.044 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <15dce0fe6903633b4ed01aa4452d7250901d5a29cbf7f2c5916c97535ee948da> but was: <6ada1415899d7135697d4823a876a4a5659c97a1d877a4d9affcd44bb5afb17c>
```