### PR TITLE
NodeServer: synchronous commit on primary propagator

### DIFF
--- a/convex-peer/docs/PERSISTENCE.md
+++ b/convex-peer/docs/PERSISTENCE.md
@@ -661,33 +661,113 @@ completes, store-backed refs arrive asynchronously, and tests need `Thread.sleep
 
 ### Design: Synchronous Commit via Sync Callback
 
-The sync callback (already hooked on `RootLatticeCursor`) would perform the full commit
-pipeline synchronously on the caller's thread: announce, persist, and merge store-backed
-refs back into the cursor — all before `sync()` returns.
+The existing `RootLatticeCursor.onSync` hook already supports synchronous commit:
+the callback runs on the caller's thread and the returned value is CASed back into
+the cursor (with lattice-merge fallback on concurrent write). No second cursor is
+needed — the single-cursor design plus CAS-or-merge gives the required guarantee.
 
-Two cursors:
-- **truthCursor** (internal) — committed state with store-backed refs
-- **appCursor** (returned by `getCursor()`) — application working copy
+#### Scope: Primary Synchronous, Secondaries Async
 
-Sync flow:
-1. `truthCursor.merge(appCursor.get())` — push app changes to truth
-2. `Cells.announce()` + `store.setRootData()` on caller's thread — persist and collect novelty
-3. Enqueue novelty for propagator's background thread — async broadcast
-4. `appCursor.merge(truthCursor.get())` — pull store-backed refs back
+Only the **primary propagator** runs synchronously on the caller's thread. Secondary
+propagators (public, backup) keep their existing async broadcast loop.
 
-**Key constraint:** `Cells.announce()` tags cells as persisted — cannot re-announce to
-collect novelty. Announce + novelty collection must happen in the sync callback, with
-novelty handed to the propagator for async broadcast.
+Rationale:
+- Primary is the durability anchor — `sync()` returning means the value reached disk.
+- Secondaries are best-effort broadcast; their latency does not affect durability.
+- Caller's thread does **one** store write (primary), not N. Bounded cost.
 
-Both `appCursor.sync()` and `processLatticeValue` use the same `mergeAndCommit` method
-— no duplicate code paths.
+#### Sync Flow
+
+Caller's thread (inside the `onSync` callback) runs the primary's full pipeline:
+1. `value = filter.apply(cursor value)` — primary has no filter; identity
+2. `announced, novelty = Cells.announce(value, primaryStore)` — primary store, primary novelty
+3. `store.setRootData(announced)` — durability barrier
+4. Encode delta from novelty and broadcast to primary's peers (Netty fire-and-forget)
+5. For each secondary propagator: `triggerBroadcast(value)` — async fan-out
+6. Return `announced` — `RootLatticeCursor.sync()` CASes it back, merge fallback handles concurrent app writes
+
+Steps 1-4 are the same pipeline today executed by the propagator's background
+thread. The change is to expose it as a method (`processSnapshot`) callable on
+any thread, and call it directly from the sync callback for the primary.
+
+The primary's background thread still exists for non-sync triggers:
+- Periodic root sync (Tier 2 divergence detection)
+- `pull()` callbacks
+- Any other async `triggerBroadcast` invocations
+
+Secondary propagators' background threads (unchanged behaviour):
+- Apply their own filter
+- `Cells.announce(filtered, ownStore)` — produces filtered novelty against own store
+- `setRootData(filtered)`, `broadcast(delta)`
+
+#### Per-Propagator Novelty is a Security Boundary
+
+**Novelty MUST be computed per-propagator, against that propagator's store, after
+that propagator's filter.** Sharing novelty across propagators would broadcast cells
+that were never tracked in the public propagator's store, bypassing its filter and
+leaking private data.
+
+```
+Primary (no filter, primary store):
+  announce(value, primaryStore) → primaryNovelty
+  → broadcast primaryNovelty (only if primary has peers)
+
+Public propagator (public filter, public store):
+  announce(filter(value), publicStore) → publicNovelty   ← independent
+  → broadcast publicNovelty
+```
+
+Each propagator's announce IS its security boundary. Cross-propagator novelty
+sharing is forbidden.
+
+#### Concurrency
+
+`Cells.announce()` tags cells as persisted — once a cell is announced to a store,
+re-announcing returns no novelty. The pipeline is therefore single-pass: the
+thread that announces also encodes and broadcasts, with novelty held in a local
+variable. No cross-thread novelty handoff.
+
+EtchStore today serialises all writes on a class-level `synchronized` (`Etch.java:321`).
+Multiple caller threads syncing concurrently will contend on this monitor. Acceptable
+for v1; see "Follow-ups" below for narrowing the lock to per-region writes.
+
+Concurrent app writes during sync are handled by `RootLatticeCursor.sync()`: it
+CASes the announced value back into the cursor, falling back to lattice merge if
+the CAS fails. The merge combines the store-backed announced value with any
+in-memory writes that landed during the announce — no data loss, store-backed refs
+preserved for cells that overlap.
+
+#### Error Propagation
+
+If announce or setRootData throws, the exception propagates to the `sync()` caller.
+Today these errors are logged on the background thread and silently dropped from the
+caller's view. Synchronous commit makes durability failures visible — a `sync()` that
+returns successfully means the value reached disk; a `sync()` that throws means it
+did not.
+
+#### Pull Path Unchanged (For Now)
+
+`LatticePropagator.pull()` remains async and continues to use its own `mergeCallback`
+to feed acquired values into the cursor. Unifying pull with the sync path is deferred
+(see Follow-ups).
 
 ### Benefits
 
-- `sync()` guarantees persistence before returning
-- Store-backed refs are immediate — no OOM from lingering strong refs
+- `sync()` guarantees primary persistence before returning
+- Store-backed refs immediate — no OOM from lingering strong refs
 - No `Thread.sleep` in tests
-- No locking — caller's thread does announce; background thread only broadcasts
+- Caller-visible durability errors
+- Per-propagator novelty preserves filter security boundaries
+
+### Follow-ups (deferred)
+
+- **Etch lock granularity** — narrow the class-level `synchronized` on Etch writes
+  to a smaller per-region or per-write critical section. Current coarse lock will
+  serialise concurrent caller-thread syncs.
+- **Pull path unification** — rewrite `LatticePropagator.pull()` to drive
+  `cursor.merge(acquired)` directly and retire the `mergeCallback` API.
+- **`mergeCallback` retirement** — once pull is migrated, delete the callback
+  mechanism entirely.
 
 ## Testing Strategy
 

--- a/convex-peer/src/main/java/convex/node/LatticePropagator.java
+++ b/convex-peer/src/main/java/convex/node/LatticePropagator.java
@@ -31,6 +31,7 @@ import convex.core.message.MessageType;
 import convex.core.store.AStore;
 import convex.core.util.LatestUpdateQueue;
 import convex.core.util.Utils;
+import convex.lattice.cursor.Root;
 
 /**
  * Self-contained component for propagating lattice values.
@@ -128,9 +129,19 @@ public class LatticePropagator implements Closeable {
 	private long persistInterval = 30_000L;
 
 	/**
-	 * Last value that was announced to the store
+	 * Cursor holding the last value announced to this propagator's store.
+	 *
+	 * <p>This is the propagator's cached view of what it has published — the
+	 * filtered, store-backed snapshot it most recently announced. LATTICE_QUERY
+	 * responses are served from this cursor, so peers only see data this
+	 * propagator has actually committed (and whose cells the store can resolve
+	 * via DATA_REQUEST).
+	 *
+	 * <p>Each propagator owns its own announced cursor; secondary propagators
+	 * with filters publish a different (filtered) view from the primary, which
+	 * is the security boundary for cross-propagator data segregation.
 	 */
-	private ACell lastAnnouncedValue;
+	private final Root<ACell> announcedCursor = new Root<>();
 
 	/**
 	 * Last value that was triggered (used for periodic root sync)
@@ -278,7 +289,12 @@ public class LatticePropagator implements Closeable {
 
 	public boolean isRunning() { return running; }
 	public long getBroadcastCount() { return broadcastCount; }
-	public ACell getLastAnnouncedValue() { return lastAnnouncedValue; }
+	public ACell getLastAnnouncedValue() { return announcedCursor.get(); }
+	/**
+	 * Cursor holding the last value announced by this propagator. See
+	 * {@link #announcedCursor} for ownership and security semantics.
+	 */
+	public Root<ACell> getAnnouncedCursor() { return announcedCursor; }
 	public long getLastBroadcastTime() { return lastBroadcastTime; }
 	public long getLastRootSyncTime() { return lastRootSyncTime; }
 	public long getRootSyncCount() { return rootSyncCount; }
@@ -295,7 +311,7 @@ public class LatticePropagator implements Closeable {
 		}
 
 		running = true;
-		lastAnnouncedValue = null;
+		announcedCursor.set(null);
 		lastTriggeredValue = null;
 		lastBroadcastTime = 0L;
 		lastRootSyncTime = 0L;
@@ -485,7 +501,7 @@ public class LatticePropagator implements Closeable {
 			broadcastCount++;
 		}
 
-		lastAnnouncedValue = value;
+		announcedCursor.set(value);
 		return value;
 	}
 
@@ -631,6 +647,6 @@ public class LatticePropagator implements Closeable {
 		}
 
 		return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
-			.thenApply(v -> lastAnnouncedValue);
+			.thenApply(v -> announcedCursor.get());
 	}
 }

--- a/convex-peer/src/main/java/convex/node/LatticePropagator.java
+++ b/convex-peer/src/main/java/convex/node/LatticePropagator.java
@@ -393,7 +393,7 @@ public class LatticePropagator implements Closeable {
 				}
 
 				if (value != null) {
-					processValue(value);
+					processSnapshotSafe(value);
 				}
 
 				// Periodic root sync only while running
@@ -405,7 +405,7 @@ public class LatticePropagator implements Closeable {
 				// Drain remaining items before exiting
 				ACell remaining;
 				while ((remaining = triggerQueue.poll()) != null) {
-					processValue(remaining);
+					processSnapshotSafe(remaining);
 				}
 				break;
 			} catch (Exception e) {
@@ -414,6 +414,20 @@ public class LatticePropagator implements Closeable {
 			}
 		}
 		log.debug("LatticePropagator loop ended");
+	}
+
+	/**
+	 * Background-thread wrapper around {@link #processSnapshot}. IOException
+	 * is logged rather than propagated — the background path is best-effort
+	 * (callers who need durability errors should call {@link #processSnapshot}
+	 * directly).
+	 */
+	private void processSnapshotSafe(ACell value) {
+		try {
+			processSnapshot(value);
+		} catch (IOException e) {
+			log.warn("Error processing lattice value", e);
+		}
 	}
 
 	/**
@@ -429,46 +443,50 @@ public class LatticePropagator implements Closeable {
 	 * setRootData is gated by {@link #persistInterval}. The merge callback
 	 * is gated by whether it was set (primary propagator only). Broadcast
 	 * is gated by peer existence and minimum delay.
+	 *
+	 * <p>Callable from any thread. The background propagation loop calls this
+	 * for queued triggers; for synchronous commit, NodeServer's sync callback
+	 * calls this directly on the caller's thread for the primary propagator.
+	 *
+	 * @param value Snapshot to process (must not be null)
+	 * @return The announced (store-backed) value
+	 * @throws IOException If announce or setRootData fails
 	 */
-	private void processValue(ACell value) {
-		try {
-			// 1. Announce to store (writes cells, collects novelty for delta)
-			ArrayList<ACell> novelty = new ArrayList<>();
-			Consumer<Ref<ACell>> noveltyHandler = r -> novelty.add(r.getValue());
-			value = Cells.announce(value, noveltyHandler, store);
+	public ACell processSnapshot(ACell value) throws IOException {
+		// 1. Announce to store (writes cells, collects novelty for delta)
+		ArrayList<ACell> novelty = new ArrayList<>();
+		Consumer<Ref<ACell>> noveltyHandler = r -> novelty.add(r.getValue());
+		value = Cells.announce(value, noveltyHandler, store);
 
-			// 2. Set root data for restore (if persist enabled)
-			if (persistInterval > 0) {
-				store.setRootData(value);
-			}
-
-			// 3. Merge callback (feed store-backed value back to cursor)
-			if (mergeCallback != null) {
-				mergeCallback.accept(value);
-			}
-
-			// 4. Broadcast to peers (only if peers exist and delay elapsed)
-			long currentTime = Utils.getCurrentTimestamp();
-			if (!connectionManager.getPeers().isEmpty()
-					&& currentTime >= lastBroadcastTime + MIN_BROADCAST_DELAY) {
-				// Ensure root value is in the novelty list
-				if (novelty.isEmpty() || !novelty.get(novelty.size() - 1).equals(value)) {
-					novelty.add(value);
-				}
-				Blob deltaData = Format.encodeDelta(novelty);
-				AVector<ACell> emptyPath = Vectors.empty();
-				AVector<?> payload = Vectors.create(MessageTag.LATTICE_VALUE, emptyPath, value);
-				Message message = Message.create(MessageType.LATTICE_VALUE, payload, deltaData);
-				connectionManager.broadcast(message);
-				lastBroadcastTime = currentTime;
-				broadcastCount++;
-			}
-
-			lastAnnouncedValue = value;
-
-		} catch (IOException e) {
-			log.warn("Error processing lattice value", e);
+		// 2. Set root data for restore (if persist enabled)
+		if (persistInterval > 0) {
+			store.setRootData(value);
 		}
+
+		// 3. Merge callback (feed store-backed value back to cursor)
+		if (mergeCallback != null) {
+			mergeCallback.accept(value);
+		}
+
+		// 4. Broadcast to peers (only if peers exist and delay elapsed)
+		long currentTime = Utils.getCurrentTimestamp();
+		if (!connectionManager.getPeers().isEmpty()
+				&& currentTime >= lastBroadcastTime + MIN_BROADCAST_DELAY) {
+			// Ensure root value is in the novelty list
+			if (novelty.isEmpty() || !novelty.get(novelty.size() - 1).equals(value)) {
+				novelty.add(value);
+			}
+			Blob deltaData = Format.encodeDelta(novelty);
+			AVector<ACell> emptyPath = Vectors.empty();
+			AVector<?> payload = Vectors.create(MessageTag.LATTICE_VALUE, emptyPath, value);
+			Message message = Message.create(MessageType.LATTICE_VALUE, payload, deltaData);
+			connectionManager.broadcast(message);
+			lastBroadcastTime = currentTime;
+			broadcastCount++;
+		}
+
+		lastAnnouncedValue = value;
+		return value;
 	}
 
 	// ========== Root Sync ==========

--- a/convex-peer/src/main/java/convex/node/LatticePropagator.java
+++ b/convex-peer/src/main/java/convex/node/LatticePropagator.java
@@ -144,24 +144,29 @@ public class LatticePropagator implements Closeable {
 	private final Root<ACell> announcedCursor = new Root<>();
 
 	/**
-	 * Last value that was triggered (used for periodic root sync)
+	 * Last value that was triggered (used for periodic root sync). Volatile
+	 * because it may be written by the caller's thread (synchronous commit
+	 * path) and read by the background propagation thread.
 	 */
 	private volatile ACell lastTriggeredValue;
 
 	/**
-	 * Timestamp of last broadcast
+	 * Timestamp of last broadcast. Volatile for cross-thread visibility — the
+	 * caller's thread (synchronous commit path) and the background propagation
+	 * thread may both read and write this.
 	 */
-	private long lastBroadcastTime = 0L;
+	private volatile long lastBroadcastTime = 0L;
 
 	/**
-	 * Timestamp of last root sync broadcast
+	 * Timestamp of last root sync broadcast (background thread only).
 	 */
 	private long lastRootSyncTime = 0L;
 
 	/**
-	 * Count of broadcasts sent
+	 * Count of broadcasts sent. Atomic because both the caller's thread and
+	 * the background thread may increment.
 	 */
-	private long broadcastCount = 0L;
+	private final java.util.concurrent.atomic.AtomicLong broadcastCount = new java.util.concurrent.atomic.AtomicLong();
 
 	/**
 	 * Count of root sync broadcasts sent
@@ -288,7 +293,7 @@ public class LatticePropagator implements Closeable {
 	}
 
 	public boolean isRunning() { return running; }
-	public long getBroadcastCount() { return broadcastCount; }
+	public long getBroadcastCount() { return broadcastCount.get(); }
 	public ACell getLastAnnouncedValue() { return announcedCursor.get(); }
 	/**
 	 * Cursor holding the last value announced by this propagator. See
@@ -315,6 +320,7 @@ public class LatticePropagator implements Closeable {
 		lastTriggeredValue = null;
 		lastBroadcastTime = 0L;
 		lastRootSyncTime = 0L;
+		broadcastCount.set(0L);
 
 		propagationThread = new Thread(this::propagationLoop, "Lattice propagator thread");
 		propagationThread.setDaemon(true);
@@ -469,6 +475,9 @@ public class LatticePropagator implements Closeable {
 	 * @throws IOException If announce or setRootData fails
 	 */
 	public ACell processSnapshot(ACell value) throws IOException {
+		// Track latest snapshot for periodic root sync (used by background thread)
+		lastTriggeredValue = value;
+
 		// 1. Announce to store (writes cells, collects novelty for delta)
 		ArrayList<ACell> novelty = new ArrayList<>();
 		Consumer<Ref<ACell>> noveltyHandler = r -> novelty.add(r.getValue());
@@ -498,7 +507,7 @@ public class LatticePropagator implements Closeable {
 			Message message = Message.create(MessageType.LATTICE_VALUE, payload, deltaData);
 			connectionManager.broadcast(message);
 			lastBroadcastTime = currentTime;
-			broadcastCount++;
+			broadcastCount.incrementAndGet();
 		}
 
 		announcedCursor.set(value);

--- a/convex-peer/src/main/java/convex/node/NodeServer.java
+++ b/convex-peer/src/main/java/convex/node/NodeServer.java
@@ -135,12 +135,35 @@ public class NodeServer<V extends ACell> implements Closeable {
 		this.port = this.config.getPort();
 		this.cursor = Cursors.createLattice(lattice);
 
-		// Hook sync callback: cursor.sync() triggers all propagators
+		// Hook sync callback: synchronous commit on the primary propagator,
+		// async fan-out to secondaries.
+		//
+		// The primary's full pipeline (announce + setRootData + broadcast) runs
+		// on the caller's thread, so cursor.sync() is a real durability barrier:
+		// returning successfully means the value has reached the primary store.
+		// IOException from announce or setRootData is wrapped and propagated to
+		// the caller — sync failures are visible, not silently dropped.
+		//
+		// Secondary propagators use the existing async path; their broadcast
+		// latency is independent of caller durability.
+		//
+		// The returned (announced/store-backed) value is CASed back into the
+		// cursor by RootLatticeCursor.sync(), with lattice-merge fallback if a
+		// concurrent app write changed the cursor during the announce.
 		this.cursor.onSync(value -> {
-			for (LatticePropagator p : propagators) {
-				p.triggerBroadcast(value);
+			if (propagators.isEmpty()) return value;
+			ACell announced;
+			try {
+				announced = propagators.get(0).processSnapshot(value);
+			} catch (IOException e) {
+				throw new RuntimeException("NodeServer sync failed: persistence error", e);
 			}
-			return value;
+			for (int i = 1; i < propagators.size(); i++) {
+				propagators.get(i).triggerBroadcast(value);
+			}
+			@SuppressWarnings("unchecked")
+			V typed = (V) announced;
+			return typed;
 		});
 
 		// Initialize receive action for handling incoming messages

--- a/convex-peer/src/main/java/convex/node/NodeServer.java
+++ b/convex-peer/src/main/java/convex/node/NodeServer.java
@@ -38,6 +38,7 @@ import convex.lattice.P2PLattice;
 import convex.lattice.LatticeContext;
 import convex.lattice.cursor.ALatticeCursor;
 import convex.lattice.cursor.Cursors;
+import convex.lattice.cursor.Root;
 import convex.lattice.cursor.RootLatticeCursor;
 import convex.net.AServer;
 import convex.net.impl.netty.NettyServer;
@@ -393,14 +394,18 @@ public class NodeServer<V extends ACell> implements Closeable {
 		ACell id = payload.get(1);
 		AVector<?> pathVector = RT.ensureVector(payload.count() > 2 ? payload.get(2) : null);
 
-		// Use the last announced value — already persisted in the store, so
-		// DATA_REQUEST can resolve any child cells the requester needs
-		ACell announced = propagators.isEmpty() ? null : propagators.get(0).getLastAnnouncedValue();
+		// Read from the propagator's announced cursor — its cells are already
+		// in the propagator's store, so DATA_REQUEST can resolve any child
+		// cells the requester needs. Each propagator owns its announced cursor;
+		// this is the security boundary for cross-propagator data segregation.
 		ACell valueAtPath;
-		if (pathVector != null && pathVector.count() > 0) {
-			valueAtPath = RT.getIn(announced, pathVector.toCellArray());
+		if (propagators.isEmpty()) {
+			valueAtPath = null;
 		} else {
-			valueAtPath = announced;
+			Root<ACell> announced = propagators.get(0).getAnnouncedCursor();
+			valueAtPath = (pathVector != null && pathVector.count() > 0)
+				? announced.get(pathVector.toCellArray())
+				: announced.get();
 		}
 
 		Result result = Result.create(id, valueAtPath);

--- a/convex-peer/src/test/java/convex/node/LatticePropagatorTest.java
+++ b/convex-peer/src/test/java/convex/node/LatticePropagatorTest.java
@@ -128,8 +128,8 @@ public class LatticePropagatorTest {
 		}
 		Index<Hash, ACell> updatedDataIndex = dataIndex.assoc(valueHash, testValue);
 		server2.getCursor().assoc(dataKeyword, updatedDataIndex);
+		// Synchronous commit: sync() returns after primary announce + setRootData
 		server2.getCursor().sync();
-		Thread.sleep(100); // Let propagator process the sync
 
 		// Pull from server2 into server1
 		assertTrue(server1.pull(), "Pull should complete successfully");
@@ -160,8 +160,8 @@ public class LatticePropagatorTest {
 			}
 			Index<Hash, ACell> updatedDataIndex = dataIndex.assoc(valueHash, testValue);
 			server1.getCursor().assoc(dataKeyword, updatedDataIndex);
+			// Synchronous commit: sync() returns after primary announce + setRootData
 			server1.getCursor().sync();
-			Thread.sleep(100); // Let propagator process the sync
 
 			// Pull from server1 into server2
 			assertTrue(server2.pull(), "Pull should complete successfully for update " + (i + 1));

--- a/convex-peer/src/test/java/convex/node/NodeNetworkTest.java
+++ b/convex-peer/src/test/java/convex/node/NodeNetworkTest.java
@@ -198,9 +198,9 @@ public class NodeNetworkTest {
 		// Update the :data path with the updated Index
 		server0.getCursor().assoc(dataKeyword, updatedDataIndex);
 
-		// Sync so the propagator has the value for LATTICE_QUERY responses
+		// Sync so the propagator has the value for LATTICE_QUERY responses.
+		// Synchronous commit: announce completes on this thread before return.
 		server0.getCursor().sync();
-		Thread.sleep(100);
 
 		// Create the query path [:data valueHash] for reuse
 		AVector<ACell> queryPath = Vectors.create(dataKeyword, valueHash);

--- a/convex-peer/src/test/java/convex/node/NodeServerPersistenceTest.java
+++ b/convex-peer/src/test/java/convex/node/NodeServerPersistenceTest.java
@@ -3,10 +3,12 @@ package convex.node;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.concurrent.CountDownLatch;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -95,9 +97,10 @@ public class NodeServerPersistenceTest {
 	 * the cursor but not yet announced.
 	 */
 	private void syncBackupFromPrimary() throws Exception {
-		// Sync primary so propagator has the latest value for query responses
+		// Sync primary so propagator has the latest value for query responses.
+		// Synchronous commit guarantees announce + setRootData complete before
+		// sync() returns — the announced cursor is up to date.
 		primary.getCursor().sync();
-		Thread.sleep(100); // Let propagator process the sync
 
 		InetSocketAddress primaryAddr = primary.getHostAddress();
 		AccountKey peerKey = AKeyPair.generate().getAccountKey();
@@ -365,11 +368,9 @@ public class NodeServerPersistenceTest {
 
 		writeDataValue(primary, 42);
 
-		// Sync cursor (triggers propagator via onSync callback)
+		// Sync cursor — synchronous commit on the primary completes announce
+		// + setRootData on this thread before returning.
 		primary.getCursor().sync();
-
-		// Give propagator thread time to process
-		Thread.sleep(200);
 
 		// Store should have the data without needing close()
 		ACell rootData = primaryStore.getRootData();
@@ -394,7 +395,6 @@ public class NodeServerPersistenceTest {
 
 		writeDataValue(primary, 77);
 		primary.getCursor().sync();
-		Thread.sleep(200);
 
 		// Verify persisted
 		ACell rootData = primaryStore.getRootData();
@@ -413,5 +413,81 @@ public class NodeServerPersistenceTest {
 		primary.launch();
 		assertEquals(CVMLong.create(77), readDataValue(primary, 77),
 			"Local-only node should restore data from store");
+	}
+
+	/**
+	 * Synchronous commit must surface persistence errors to the caller. If
+	 * setRootData throws, cursor.sync() must throw — silent loss of durability
+	 * is the failure mode this design rules out.
+	 */
+	@Test
+	public void testSyncSurfacesPersistenceFailure() throws Exception {
+		// EtchStore subclass that throws on setRootData to simulate a disk error
+		EtchStore failingStore = new EtchStore(EtchStore.createTemp("failing").getEtch()) {
+			@Override
+			public <T extends ACell> convex.core.data.Ref<T> setRootData(T data) throws IOException {
+				throw new IOException("simulated disk failure");
+			}
+		};
+		primaryStore = failingStore;
+
+		primary = new NodeServer<>(Lattice.ROOT, primaryStore, NodeConfig.port(-1));
+		primary.launch();
+		writeDataValue(primary, 99);
+
+		// sync() must propagate, not swallow
+		RuntimeException ex = assertThrows(RuntimeException.class,
+			() -> primary.getCursor().sync(),
+			"sync() must throw when setRootData fails");
+		assertTrue(ex.getCause() instanceof IOException,
+			"Cause must be the original IOException, was: " + ex.getCause());
+		assertEquals("simulated disk failure", ex.getCause().getMessage());
+	}
+
+	/**
+	 * Concurrent app writes during sync must not be lost. Thread A calls
+	 * {@code sync()} (announce + setRootData on caller's thread); thread B
+	 * writes a new key to the cursor mid-sync. After both, both writes must
+	 * be visible — the {@code RootLatticeCursor.sync()} CAS-or-merge fallback
+	 * is what guarantees this.
+	 *
+	 * <p>Thread B writes at a fresh top-level key per iteration via the
+	 * cursor's atomic {@code assoc}, so the only relevant race is the one
+	 * inside sync (B's write landing between A's snapshot capture and A's CAS).
+	 * The iteration count is high enough to make the race likely to be hit.
+	 */
+	@Test
+	public void testConcurrentWriteDuringSync() throws Exception {
+		primaryStore = EtchStore.createTemp("primary-concurrent");
+		primary = new NodeServer<>(Lattice.ROOT, primaryStore, NodeConfig.port(-1));
+		primary.launch();
+
+		Keyword stable = Keyword.intern("stable");
+		primary.getCursor().assoc(stable, CVMLong.create(1));
+
+		for (int i = 0; i < 50; i++) {
+			final Keyword bKey = Keyword.intern("b-" + i);
+			final ACell bValue = CVMLong.create(i);
+
+			CountDownLatch ready = new CountDownLatch(1);
+			Thread b = new Thread(() -> {
+				try {
+					ready.await();
+					primary.getCursor().assoc(bKey, bValue);
+				} catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+				}
+			});
+			b.start();
+			ready.countDown();
+			primary.getCursor().sync();
+			b.join();
+
+			// B's write must survive the CAS-or-merge fallback inside sync()
+			assertEquals(bValue, primary.getCursor().get(bKey),
+				"Concurrent write at " + bKey + " must not be lost by sync at iteration " + i);
+			assertEquals(CVMLong.create(1), primary.getCursor().get(stable),
+				"Pre-existing :stable must survive concurrent sync at iteration " + i);
+		}
 	}
 }

--- a/convex-peer/src/test/java/convex/node/NodeServerTest.java
+++ b/convex-peer/src/test/java/convex/node/NodeServerTest.java
@@ -451,11 +451,10 @@ public class NodeServerTest {
 		maxNodeServer.launch();
 		assertTrue(maxNodeServer.isRunning());
 
-		// Set a value and sync so it flows through the propagator pipeline
+		// Set a value and sync so it flows through the propagator pipeline.
+		// Synchronous commit: announce + setRootData run on this thread.
 		maxNodeServer.getCursor().set(CVMLong.create(42));
 		maxNodeServer.getCursor().sync();
-		// Wait for propagator to process (async)
-		Thread.sleep(100);
 		
 		// Get the server address
 		InetSocketAddress serverAddress = maxNodeServer.getHostAddress();
@@ -696,12 +695,16 @@ public class NodeServerTest {
 				// Fire-and-forget: LATTICE_VALUE has no request ID, no response expected
 				convex.message(msg);
 
-				// Wait for the chain: message delivery → merge → internal sync → propagator
-				// Keep connection open during wait — closing too early can drop unsent data
+				// Wait for network delivery. With synchronous commit, once
+				// processLatticeValue runs on the netty thread, the merge and
+				// the resulting sync (including primary announce) all complete
+				// before the netty handler returns — so we just wait for the
+				// message to arrive. Keep connection open: closing too early
+				// can drop unsent data.
 				long deadline = System.currentTimeMillis() + 3000;
 				while (System.currentTimeMillis() < deadline) {
 					if (propagator.getLastAnnouncedValue() != null) break;
-					Thread.sleep(50);
+					Thread.sleep(10);
 				}
 			} finally {
 				convex.close();
@@ -747,15 +750,9 @@ public class NodeServerTest {
 			// Local write path: set value directly on cursor, then sync explicitly.
 			// This is how application code drives the node — sync() is the caller's
 			// responsibility (unlike the incoming message path which syncs internally).
+			// Synchronous commit: sync() returns after the primary's announce.
 			node.getCursor().set(CVMLong.create(42));
 			node.getCursor().sync();
-
-			// Wait for propagator to process
-			long deadline = System.currentTimeMillis() + 3000;
-			while (System.currentTimeMillis() < deadline) {
-				if (propagator.getLastAnnouncedValue() != null) break;
-				Thread.sleep(50);
-			}
 
 			// Explicit sync should always work — this is the control
 			assertNotNull(propagator.getLastAnnouncedValue(),


### PR DESCRIPTION
## Summary

Make `cursor.sync()` a real durability barrier. The primary propagator's full pipeline (announce + setRootData + broadcast) now runs on the caller's thread inside the sync callback. Returning successfully means the value reached the primary store; persistence errors propagate as `RuntimeException` instead of being silently dropped on a background thread.

Secondary propagators keep their existing async path. Per-propagator novelty is preserved as the security boundary — each secondary computes its own filtered novelty against its own store on its own thread (no cross-propagator novelty sharing).

## Changes

- **`PERSISTENCE.md`** — design section for synchronous commit on primary, with per-propagator novelty as security invariant and three deferred follow-ups (Etch lock granularity, pull path unification, mergeCallback retirement).
- **`LatticePropagator`** — `processSnapshot(value)` exposed as a thread-callable method returning the announced value. Last-announced state moves into a `Root<ACell> announcedCursor` owned by the propagator. Cross-thread fields gain `volatile` / `AtomicLong` guards.
- **`NodeServer.onSync`** — calls `primary.processSnapshot` on the caller's thread; secondaries get the existing `triggerBroadcast`. `IOException` wrapped to `RuntimeException`.
- **`NodeServer.processLatticeQuery`** — reads the announced cursor via `cursor.get(path)` instead of manual `RT.getIn` traversal.
- **Tests** — 8 `Thread.sleep` calls dropped (all were waiting for the now-synchronous primary). New tests: `testSyncSurfacesPersistenceFailure` (IOException propagation), `testConcurrentWriteDuringSync` (CAS-or-merge fallback under racing app writes).

## Why

`cursor.sync()` previously returned before persistence completed. Symptoms:
- 9 `Thread.sleep` calls in tests (flaky reliability debt).
- OOM window between sync return and store-back (strong refs).
- Persistence failures logged on the propagator thread, not visible to the caller — silent durability loss.

Synchronous commit closes all three. Per-propagator novelty is a security correctness fix: sharing novelty across propagators would have leaked private cells through public broadcast channels.

## Test plan

- [x] `mvn -pl convex-peer test` — 216/216 (was 214; +2 new sync-commit tests)
- [x] `mvn -pl convex-dlfs test` — 67/67
- [x] Removed `Thread.sleep` calls verified — all node tests still pass deterministically
- [x] `testSyncSurfacesPersistenceFailure` — confirms IOException → RuntimeException wrap
- [x] `testConcurrentWriteDuringSync` — 50 iterations exercise CAS-or-merge fallback