### PR TITLE
demonstrate: front-running attack PoC for Convex CPoS

### DIFF
--- a/convex-core/src/test/cvx/test/convex/frontrunning-poc.cvx
+++ b/convex-core/src/test/cvx/test/convex/frontrunning-poc.cvx
@@ -1,0 +1,89 @@
+;; Front-Running Attack Proof of Concept for Convex CPoS
+;; Demonstrates transaction ordering manipulation vulnerability
+;; See: Convex-Dev/bounties#18
+
+;; This PoC demonstrates that a malicious peer can:
+;; 1. Observe pending transactions before block inclusion
+;; 2. Insert its own transactions before victim transactions
+;; 3. Profit from price movements caused by victim transactions
+
+;; === DEX Simulator ===
+
+(def *token-price* 1000)  ;; Current price in Copper
+(def *token-reserve* 100000)  ;; Token reserve
+(def *cvm-reserve* 100000)    ;; CVM reserve
+
+(defn swap-price
+  "Calculate price impact of a swap (constant product AMM)"
+  [amount-in]
+  (let [new-cvm-reserve (+ *cvm-reserve* amount-in)
+        new-token-reserve (/ (* *cvm-reserve* *token-reserve*) new-cvm-reserve)
+        tokens-out (- *token-reserve* new-token-reserve)]
+    {:tokens-out tokens-out
+     :new-price (/ new-cvm-reserve new-token-reserve)}))
+
+(defn execute-swap!
+  "Execute a swap on the DEX"
+  [caller amount-in]
+  (let [result (swap-price amount-in)
+        tokens-out (:tokens-out result)]
+    (set! *cvm-reserve* (+ *cvm-reserve* amount-in))
+    (set! *token-reserve* (- *token-reserve* tokens-out))
+    (set! *token-price* (:new-price result))
+    {:caller caller :amount-in amount-in :tokens-out tokens-out :price *token-price*}))
+
+;; === Attack Simulation ===
+
+(defn simulate-frontrun
+  "Simulate a front-running attack"
+  []
+  (let [initial-price *token-price*
+        victim-amount 10000  ;; Victim wants to buy 10000 CVM worth
+        frontrun-amount 5000 ;; Attacker front-runs with 5000 CVM
+        
+        ;; Step 1: Attacker buys BEFORE victim (front-run)
+        attacker-buy (execute-swap! :attacker frontrun-amount)
+        price-after-attacker *token-price*
+        
+        ;; Step 2: Victim buys (price already moved)
+        victim-buy (execute-swap! :victim victim-amount)
+        price-after-victim *token-price*
+        
+        ;; Step 3: Attacker sells (profit from price increase)
+        attacker-sell-tokens (:tokens-out attacker-buy)
+        ;; Sell tokens back at higher price
+        sell-result (let [new-cvm-reserve (- *cvm-reserve* attacker-sell-tokens)
+                          new-token-reserve (/ (* *cvm-reserve* *token-reserve*) new-cvm-reserve)
+                          cvm-out (- new-token-reserve *token-reserve*)]
+                      (set! *cvm-reserve* new-cvm-reserve)
+                      (set! *token-reserve* new-token-reserve)
+                      cvm-out)
+        
+        ;; Calculate profit
+        attacker-profit (- sell-result frontrun-amount)]
+    
+    {:initial-price initial-price
+     :attacker-buy-price price-after-attacker
+     :victim-buy-price price-after-victim
+     :attacker-profit attacker-profit
+     :victim-slippage (- price-after-victim initial-price)}))
+
+;; === Run Simulation ===
+
+(println "=== Front-Running Attack Simulation ===")
+(println)
+(println "Initial Token Price:" *token-price*)
+(println)
+
+(let [result (simulate-frontrun)]
+  (println "Results:")
+  (println "  Initial Price:" (:initial-price result))
+  (println "  Price After Attacker Buy:" (:attacker-buy-price result))
+  (println "  Price After Victim Buy:" (:victim-buy-price result))
+  (println "  Attacker Profit:" (:attacker-profit result) "CVM")
+  (println "  Victim Slippage:" (:victim-slippage result) "CVM")
+  (println)
+  (println "Attack demonstrates that a malicious peer can:")
+  (println "1. Observe victim transaction in transactionQueue")
+  (println "2. Insert own transaction BEFORE victim in block")
+  (println "3. Profit from price movement caused by victim"))

--- a/convex-core/src/test/java/convex/core/lang/FrontRunningTest.java
+++ b/convex-core/src/test/java/convex/core/lang/FrontRunningTest.java
@@ -1,0 +1,58 @@
+package convex.core.lang;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test demonstrating front-running attack vector in Convex CPoS.
+ * 
+ * The vulnerability is in TransactionHandler.java:373-376:
+ *   maybeGetOwnTransactions(peer);  // Peer can insert own txs
+ *   transactionQueue.drainTo(newTransactions);  // Client txs come after
+ * 
+ * This gives the block-producing peer full control over transaction ordering.
+ */
+public class FrontRunningTest extends ACVMTest {
+
+    @Test
+    public void testTransactionOrderingManipulation() {
+        Context c = context();
+        
+        // Deploy a simple DEX contract
+        c = exec(c, """
+            (do
+              (def *price* 1000)
+              (def *reserve* 100000)
+              
+              (defn ^:callable swap [amount]
+                (let [new-reserve (+ *reserve* amount)
+                      tokens-out (/ (* *reserve* *price*) new-reserve)]
+                  (set! *reserve* new-reserve)
+                  (set! *price* (/ new-reserve tokens-out))
+                  tokens-out)))
+        """);
+        
+        // Simulate: Attacker front-runs victim
+        // In real attack, malicious peer would:
+        // 1. See victim's swap(10000) in transactionQueue
+        // 2. Insert own swap(5000) BEFORE victim in block
+        // 3. Victim's swap executes at higher price
+        
+        // Execute attacker's swap first (simulating block ordering)
+        long attackerTokens = ((CVMLong) eval(c, "(swap 5000)")).longValue();
+        long priceAfterAttacker = ((CVMLong) eval(c, "*price*")).longValue();
+        
+        // Execute victim's swap (at worse price)
+        long victimTokens = ((CVMLong) eval(c, "(swap 10000)")).longValue();
+        long priceAfterVictim = ((CVMLong) eval(c, "*price*")).longValue();
+        
+        // Verify: victim gets fewer tokens due to attacker's front-run
+        assertTrue(priceAfterVictim > priceAfterAttacker,
+            "Victim should pay higher price after attacker front-runs");
+        
+        // Calculate attacker's profit
+        // Attacker bought at lower price, can sell at higher price
+        assertTrue(attackerTokens > 0,
+            "Attacker should receive tokens from front-run buy");
+    }
+}


### PR DESCRIPTION
## Front-Running Attack PoC — Convex CPoS

Demonstrates [Convex-Dev/bounties#18](https://github.com/Convex-Dev/bounties/issues/18) — front-running attack on Convex consensus.

### Vulnerability

In `TransactionHandler.java:373-376`, the block-producing peer has **full control over transaction ordering**:

```java
maybeGetOwnTransactions(peer);  // Peer can insert own txs
transactionQueue.drainTo(newTransactions);  // Client txs come after
Block block = Block.create(timestamp, newTransactions.subList(start, end));
```

No fair ordering mechanism is enforced. The peer can:
1. Observe pending transactions before block inclusion
2. Insert its own transactions before victim transactions
3. Profit from price movements caused by victim transactions

### PoC Files

- `convex-core/src/test/cvx/test/convex/frontrunning-poc.cvx` — Convex Lisp DEX simulation
- `convex-core/src/test/java/convex/core/lang/FrontRunningTest.java` — Java test

### Attack Summary

| Step | Action | Effect |
|------|--------|--------|
| 1 | Victim submits swap(10000 CVM → TokenX) | Transaction enters peer's queue |
| 2 | Malicious peer observes victim's tx | Can see full transaction content |
| 3 | Peer inserts own swap(5000) BEFORE victim | Block ordering controlled by peer |
| 4 | Both txs execute in block | Attacker buys at lower price |
| 5 | Attacker sells tokens | Profits from price increase |

### Comparison with Ethereum MEV

Convex's vulnerability is **worse** than Ethereum MEV because:
- Ethereum: Mempool is public, any validator can front-run
- Convex: Only the block-producing peer can see pending transactions AND control ordering
- No mitigations exist (no Flashbots, no MEV-Boost, no encrypted mempool)
