### PR TITLE
feat: add BigDecimal type to CVM (bounty #5)

### DIFF
--- a/convex-core/src/main/java/convex/core/cvm/Juice.java
+++ b/convex-core/src/main/java/convex/core/cvm/Juice.java
@@ -7,6 +7,7 @@ import convex.core.data.ACountable;
 import convex.core.data.ADataStructure;
 import convex.core.data.Cells;
 import convex.core.data.prim.ANumeric;
+import convex.core.data.prim.CVMBigDecimal;
 import convex.core.data.prim.CVMBigInteger;
 import convex.core.data.prim.CVMDouble;
 
@@ -515,6 +516,10 @@ public class Juice {
 		if (!(a instanceof ANumeric)) return -1;
 		if (a instanceof CVMBigInteger) {
 			long bl=((CVMBigInteger)a).byteLength();
+			return Math.max(MIN_NUMERIC_COST,bl);
+		}
+		if (a instanceof CVMBigDecimal) {
+			long bl=((CVMBigDecimal)a).getDecimal().unscaledValue().bitLength()/8+1;
 			return Math.max(MIN_NUMERIC_COST,bl);
 		}
 		return MIN_NUMERIC_COST;

--- a/convex-core/src/main/java/convex/core/cvm/Symbols.java
+++ b/convex-core/src/main/java/convex/core/cvm/Symbols.java
@@ -258,6 +258,9 @@ public class Symbols {
 	public static final Symbol ACTOR_Q = intern("actor?");
 
 	public static final Symbol ZERO_Q = intern("zero?");
+	
+	public static final Symbol BIGDECIMAL = intern("bigdecimal");
+	public static final Symbol BIGDECIMAL_Q = intern("bigdecimal?");
 
 	public static final Symbol CONTAINS_KEY_Q = intern("contains-key?");
 

--- a/convex-core/src/main/java/convex/core/data/CAD3Encoder.java
+++ b/convex-core/src/main/java/convex/core/data/CAD3Encoder.java
@@ -270,6 +270,21 @@ public class CAD3Encoder extends AEncoder<ACell> {
 			ds.pos+=8;
 			return CVMDouble.unsafeCreate(Double.longBitsToDouble(bits));
 		}
+		// CVMBigDecimal: tag 0x1a, VLQ signed scale + VLQ byte count + raw unscaled bytes
+		if (tag == Tag.BIG_DECIMAL) {
+			long scale=Format.readVLQLong(ds.data, ds.pos);
+			ds.pos+=Format.getVLQLongLength(scale);
+			long bc=Format.readVLQCount(ds.data, ds.pos);
+			ds.pos+=Format.getVLQCountLength(bc);
+			if (bc>Constants.MAX_BIG_INTEGER_LENGTH) throw new BadFormatException("Encoding exceeds max big decimal unscaled length");
+			Blob blobData=Blob.wrap(ds.data, ds.pos, (int)bc);
+			ds.pos+=(int)bc;
+			java.math.BigInteger unscaled=new java.math.BigInteger(blobData.toByteArray());
+			java.math.BigDecimal bd=new java.math.BigDecimal(unscaled, (int)scale);
+			CVMBigDecimal result=CVMBigDecimal.create(bd);
+			if (result==null) throw new BadFormatException("Illegal creation of BigDecimal");
+			return result;
+		}
 		throw new BadFormatException(ErrorMessages.badTagMessage(tag));
 	}
 

--- a/convex-core/src/main/java/convex/core/data/Tag.java
+++ b/convex-core/src/main/java/convex/core/data/Tag.java
@@ -23,6 +23,7 @@ public class Tag {
 	
 	public static final byte INTEGER = (byte) 0x10; // Arbitrary length integer base
 	public static final byte BIG_INTEGER = (byte) 0x19; // Big integer (greater than long range)
+	public static final byte BIG_DECIMAL = (byte) 0x1a; // Arbitrary precision decimal
 	public static final byte DOUBLE = (byte) 0x1d;
 
     // =========================================

--- a/convex-core/src/main/java/convex/core/data/prim/CVMBigDecimal.java
+++ b/convex-core/src/main/java/convex/core/data/prim/CVMBigDecimal.java
@@ -1,0 +1,390 @@
+package convex.core.data.prim;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.MathContext;
+
+import convex.core.Constants;
+import convex.core.data.ABlob;
+import convex.core.data.ACell;
+import convex.core.data.AString;
+import convex.core.data.Blob;
+import convex.core.data.Format;
+import convex.core.data.Strings;
+import convex.core.data.Tag;
+import convex.core.data.type.AType;
+import convex.core.data.type.Types;
+import convex.core.data.util.BlobBuilder;
+import convex.core.exceptions.InvalidDataException;
+import convex.core.util.Utils;
+
+/**
+ * Arbitrary precision Decimal implementation for the CVM.
+ * 
+ * A CVMBigDecimal wraps a java.math.BigDecimal and provides exact decimal
+ * arithmetic. It is canonical if and only if it represents a value that
+ * cannot be exactly represented as an integer (i.e. has meaningful fractional digits).
+ *
+ * Type promotion rules:
+ * - BigDecimal op BigDecimal = BigDecimal (exact)
+ * - BigDecimal op Integer = BigDecimal (promote integer to BigDecimal)
+ * - Integer op BigDecimal = BigDecimal (handled via dispatch)
+ * - BigDecimal op Double = Double (promote to double, lossy)
+ */
+public final class CVMBigDecimal extends ANumeric {
+
+	/**
+	 * Maximum byte length for the unscaled value (same limit as BigInteger)
+	 */
+	private static final int MAX_UNSCALED_BYTELENGTH = Constants.MAX_BIG_INTEGER_LENGTH;
+
+	private final BigDecimal value;
+
+	private CVMBigDecimal(BigDecimal value) {
+		this.value = value.stripTrailingZeros();
+		this.memorySize = Format.FULL_EMBEDDED_MEMORY_SIZE;
+	}
+
+	/**
+	 * Creates a CVMBigDecimal from a Java BigDecimal. The value is stripped of
+	 * trailing zeros. May return a non-canonical instance if the value is actually
+	 * an integer.
+	 * 
+	 * @param value Java BigDecimal value
+	 * @return CVMBigDecimal instance, or null if value is null or too large
+	 */
+	public static CVMBigDecimal create(BigDecimal value) {
+		if (value == null) return null;
+		BigDecimal stripped = value.stripTrailingZeros();
+		// Check unscaled value size
+		BigInteger unscaled = stripped.unscaledValue();
+		int byteLen = Utils.byteLength(unscaled);
+		if (byteLen > MAX_UNSCALED_BYTELENGTH) return null;
+		return new CVMBigDecimal(stripped);
+	}
+
+	/**
+	 * Creates a canonical CVMBigDecimal from a Java BigDecimal.
+	 * Returns null if the value is actually an integer (should be CVMLong or CVMBigInteger instead).
+	 * 
+	 * @param value Java BigDecimal value
+	 * @return Canonical CVMBigDecimal, or null if value is an integer or null or too large
+	 */
+	public static CVMBigDecimal createCanonical(BigDecimal value) {
+		CVMBigDecimal result = create(value);
+		if (result == null) return null;
+		if (!result.isCanonical()) return null;
+		return result;
+	}
+
+	/**
+	 * Creates a CVMBigDecimal from a string representation.
+	 * 
+	 * @param s String containing a decimal number (e.g. "3.14", "-0.001", "1E+5")
+	 * @return CVMBigDecimal instance, or null if not parseable
+	 */
+	public static CVMBigDecimal parse(String s) {
+		try {
+			BigDecimal bd = new BigDecimal(s);
+			return create(bd);
+		} catch (NumberFormatException e) {
+			return null;
+		}
+	}
+
+	/**
+	 * Creates a CVMBigDecimal from a double value.
+	 * WARNING: This may introduce floating-point representation artifacts.
+	 * 
+	 * @param d Double value
+	 * @return CVMBigDecimal instance, or null if infinite/NaN
+	 */
+	public static CVMBigDecimal fromDouble(double d) {
+		if (!Double.isFinite(d)) return null;
+		return create(BigDecimal.valueOf(d));
+	}
+
+	/**
+	 * Creates a CVMBigDecimal from a long value (scale 0).
+	 * 
+	 * @param l Long value
+	 * @return CVMBigDecimal instance (may not be canonical since it's an integer)
+	 */
+	public static CVMBigDecimal fromLong(long l) {
+		return create(BigDecimal.valueOf(l));
+	}
+
+	/**
+	 * Creates a CVMBigDecimal from a BigInteger value (scale 0).
+	 * 
+	 * @param bi BigInteger value
+	 * @return CVMBigDecimal instance (may not be canonical since it's an integer)
+	 */
+	public static CVMBigDecimal fromBigInteger(BigInteger bi) {
+		if (bi == null) return null;
+		return create(new BigDecimal(bi));
+	}
+
+	/**
+	 * Gets the underlying Java BigDecimal value.
+	 * 
+	 * @return Java BigDecimal
+	 */
+	public BigDecimal getDecimal() {
+		return value;
+	}
+
+	/**
+	 * Gets the scale of this BigDecimal (number of digits after decimal point).
+	 * 
+	 * @return Scale
+	 */
+	public int scale() {
+		return value.scale();
+	}
+
+	/**
+	 * Gets the unscaled value of this BigDecimal.
+	 * 
+	 * @return Unscaled BigInteger value
+	 */
+	public BigInteger unscaledValue() {
+		return value.unscaledValue();
+	}
+
+	@Override
+	public AType getType() {
+		return Types.DECIMAL;
+	}
+
+	@Override
+	public CVMLong toLong() {
+		try {
+			return CVMLong.create(value.longValueExact());
+		} catch (ArithmeticException e) {
+			return null;
+		}
+	}
+
+	@Override
+	public long longValue() {
+		return value.longValue();
+	}
+
+	@Override
+	public CVMDouble toDouble() {
+		return CVMDouble.create(value.doubleValue());
+	}
+
+	@Override
+	public double doubleValue() {
+		return value.doubleValue();
+	}
+
+	@Override
+	public Class<?> numericType() {
+		return BigDecimal.class;
+	}
+
+	@Override
+	public CVMLong signum() {
+		return CVMLong.forSignum(value.signum());
+	}
+
+	@Override
+	public boolean isNegative() {
+		return value.signum() < 0;
+	}
+
+	@Override
+	public boolean isPositive() {
+		return value.signum() > 0;
+	}
+
+	@Override
+	public boolean isNatural() {
+		// A decimal is natural if it's a non-negative integer
+		if (value.signum() < 0) return false;
+		return value.stripTrailingZeros().scale() <= 0;
+	}
+
+	@Override
+	public boolean isZero() {
+		return value.signum() == 0;
+	}
+
+	@Override
+	public boolean isCanonical() {
+		// Canonical if and only if it has meaningful fractional digits
+		// i.e. it cannot be exactly represented as an integer
+		return value.stripTrailingZeros().scale() > 0;
+	}
+
+	@Override
+	public ANumeric abs() {
+		if (value.signum() >= 0) return this;
+		return create(value.abs());
+	}
+
+	@Override
+	public ANumeric negate() {
+		return create(value.negate());
+	}
+
+	@Override
+	public CVMLong ensureLong() {
+		return null; // BigDecimal is never a Long, even if numerically equal
+	}
+
+	@Override
+	public AInteger toInteger() {
+		try {
+			BigInteger bi = value.toBigIntegerExact();
+			return AInteger.create(bi);
+		} catch (ArithmeticException e) {
+			return null; // has fractional part
+		}
+	}
+
+	// ---- Arithmetic operations ----
+
+	@Override
+	public ANumeric add(ANumeric b) {
+		if (b instanceof CVMBigDecimal bd) {
+			return create(value.add(bd.value));
+		}
+		if (b instanceof AInteger ai) {
+			return create(value.add(new BigDecimal(ai.big())));
+		}
+		// Fall back to double for CVMDouble
+		return CVMDouble.create(doubleValue() + b.doubleValue());
+	}
+
+	@Override
+	public ANumeric sub(ANumeric b) {
+		if (b instanceof CVMBigDecimal bd) {
+			return create(value.subtract(bd.value));
+		}
+		if (b instanceof AInteger ai) {
+			return create(value.subtract(new BigDecimal(ai.big())));
+		}
+		return CVMDouble.create(doubleValue() - b.doubleValue());
+	}
+
+	@Override
+	public ANumeric multiply(ANumeric b) {
+		if (b instanceof CVMBigDecimal bd) {
+			return create(value.multiply(bd.value));
+		}
+		if (b instanceof AInteger ai) {
+			return create(value.multiply(new BigDecimal(ai.big())));
+		}
+		return CVMDouble.create(doubleValue() * b.doubleValue());
+	}
+
+	/**
+	 * Divides this BigDecimal by another, preserving precision.
+	 * Throws ArithmeticException if the result cannot be represented exactly.
+	 * 
+	 * @param b Divisor
+	 * @return Division result
+	 */
+	public CVMBigDecimal divideExact(CVMBigDecimal b) {
+		return create(value.divide(b.value, MathContext.UNLIMITED));
+	}
+
+	@Override
+	public int compareTo(ANumeric o) {
+		if (o instanceof CVMBigDecimal bd) {
+			return value.compareTo(bd.value);
+		}
+		if (o instanceof AInteger) {
+			// Compare BigDecimal with integer precisely
+			return value.compareTo(new BigDecimal(o.toString()));
+		}
+		// Fall back to double comparison for CVMDouble
+		return Double.compare(doubleValue(), o.doubleValue());
+	}
+
+	@Override
+	public int estimatedEncodingSize() {
+		// Tag + VLQ scale + VLQ byte count + unscaled value bytes
+		int unscaledLen = Utils.byteLength(value.unscaledValue());
+		return 1 + Format.MAX_VLQ_LONG_LENGTH + Format.getVLQCountLength(unscaledLen) + unscaledLen;
+	}
+
+	@Override
+	public int encode(byte[] bs, int pos) {
+		bs[pos++] = Tag.BIG_DECIMAL;
+		return encodeRaw(bs, pos);
+	}
+
+	@Override
+	public int encodeRaw(byte[] bs, int pos) {
+		// Encode scale as VLQ long (signed)
+		pos = Format.writeVLQLong(bs, pos, value.scale());
+		// Encode unscaled value as VLQ count + raw bytes (same format as BigInteger)
+		BigInteger unscaled = value.unscaledValue();
+		byte[] unscaledBytes = unscaled.toByteArray();
+		pos = Format.writeVLQCount(bs, pos, unscaledBytes.length);
+		System.arraycopy(unscaledBytes, 0, bs, pos, unscaledBytes.length);
+		pos += unscaledBytes.length;
+		return pos;
+	}
+
+	@Override
+	public final byte getTag() {
+		return Tag.BIG_DECIMAL;
+	}
+
+	@Override
+	public boolean print(BlobBuilder sb, long limit) {
+		AString s = Strings.create(toString());
+		if (s.count() > limit) {
+			sb.append(s.slice(0, limit));
+			return false;
+		}
+		sb.append(s);
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return value.toPlainString();
+	}
+
+	@Override
+	public AString toCVMString(long limit) {
+		if (limit < 1) return null;
+		return Strings.create(toString());
+	}
+
+	@Override
+	public boolean equals(ACell a) {
+		if (a == this) return true;
+		if (a instanceof CVMBigDecimal bd) {
+			return equals(bd);
+		}
+		return false;
+	}
+
+	public boolean equals(CVMBigDecimal a) {
+		return value.compareTo(a.value) == 0;
+	}
+
+	@Override
+	public int hashCode() {
+		return value.hashCode();
+	}
+
+	@Override
+	public void validateCell() throws InvalidDataException {
+		if (value == null) throw new InvalidDataException("Null BigDecimal value");
+		BigDecimal stripped = value.stripTrailingZeros();
+		BigInteger unscaled = stripped.unscaledValue();
+		int byteLen = Utils.byteLength(unscaled);
+		if (byteLen > MAX_UNSCALED_BYTELENGTH) {
+			throw new InvalidDataException("BigDecimal unscaled value too large: " + byteLen + " bytes");
+		}
+	}
+}

--- a/convex-core/src/main/java/convex/core/data/type/Decimal.java
+++ b/convex-core/src/main/java/convex/core/data/type/Decimal.java
@@ -1,0 +1,42 @@
+package convex.core.data.type;
+
+import convex.core.data.ACell;
+import convex.core.data.prim.CVMBigDecimal;
+import convex.core.data.prim.CVMLong;
+
+/**
+ * Type that represents CVM Decimal values (arbitrary precision)
+ */
+public final class Decimal extends ANumericType<CVMBigDecimal> {
+
+	/**
+	 * Singleton runtime instance
+	 */
+	public static final Decimal INSTANCE = new Decimal();
+
+	private Decimal() {
+		super(CVMBigDecimal.class);
+	}
+
+	@Override
+	public boolean check(ACell value) {
+		return value instanceof CVMBigDecimal;
+	}
+
+	@Override
+	public String toString() {
+		return "Decimal";
+	}
+
+	@Override
+	public CVMBigDecimal defaultValue() {
+		return CVMBigDecimal.fromLong(0);
+	}
+
+	@Override
+	public CVMBigDecimal implicitCast(ACell a) {
+		if (a instanceof CVMBigDecimal bd) return bd;
+		if (a instanceof CVMLong l) return CVMBigDecimal.fromLong(l.longValue());
+		return null;
+	}
+}

--- a/convex-core/src/main/java/convex/core/data/type/Types.java
+++ b/convex-core/src/main/java/convex/core/data/type/Types.java
@@ -23,6 +23,7 @@ public class Types {
 	public static final Long LONG=Long.INSTANCE;
 	public static final Integer INTEGER=Integer.INSTANCE;
 	public static final Double DOUBLE = Double.INSTANCE;
+	public static final Decimal DECIMAL = Decimal.INSTANCE;
 	public static final Number NUMBER = Number.INSTANCE;
 	
 	// Atomic types
@@ -75,6 +76,7 @@ public class Types {
 		LONG,
 		INTEGER,
 		DOUBLE,
+		DECIMAL,
 		
 		BOOLEAN,
 		CHARACTER,

--- a/convex-core/src/main/java/convex/core/lang/Core.java
+++ b/convex-core/src/main/java/convex/core/lang/Core.java
@@ -58,6 +58,7 @@ import convex.core.data.prim.ANumeric;
 import convex.core.data.prim.APrimitive;
 import convex.core.data.prim.CVMBool;
 import convex.core.data.prim.CVMChar;
+import convex.core.data.prim.CVMBigDecimal;
 import convex.core.data.prim.CVMDouble;
 import convex.core.data.prim.CVMLong;
 import convex.core.data.type.Types;
@@ -2866,6 +2867,24 @@ public class Core {
 		@Override
 		public boolean test(ACell val) {
 			return RT.isNumber(val);
+		}
+	});
+
+	public static final CoreFn<CVMBool> BIGDECIMAL_Q = reg(new CorePred(Symbols.BIGDECIMAL_Q,261) {
+		@Override
+		public boolean test(ACell val) {
+			return val instanceof CVMBigDecimal;
+		}
+	});
+
+	public static final CoreFn<CVMBigDecimal> BIGDECIMAL = reg(new CoreFn<>(Symbols.BIGDECIMAL,260) {
+		@Override
+		public <I> Context invoke(Context ctx, ACell[] args) {
+			if (args.length != 1) return ctx.withArityError(exactArityMessage(1, args.length));
+			ACell a = args[0];
+			CVMBigDecimal result = RT.ensureBigDecimal(a);
+			if (result == null) return ctx.withCastError(Types.DECIMAL, a);
+			return ctx.withResult(Juice.SPECIAL, result);
 		}
 	});
 

--- a/convex-core/src/main/java/convex/core/lang/RT.java
+++ b/convex-core/src/main/java/convex/core/lang/RT.java
@@ -47,6 +47,7 @@ import convex.core.data.prim.APrimitive;
 import convex.core.data.prim.CVMBigInteger;
 import convex.core.data.prim.CVMBool;
 import convex.core.data.prim.CVMChar;
+import convex.core.data.prim.CVMBigDecimal;
 import convex.core.data.prim.CVMDouble;
 import convex.core.data.prim.CVMLong;
 import convex.core.data.type.AType;
@@ -606,6 +607,20 @@ public class RT {
 			ANumeric ap = (ANumeric) a;
 			return ap.toDouble();
 		}
+		return null;
+	}
+
+	/**
+	 * Converts a numerical value to a CVM BigDecimal.
+	 * 
+	 * @param a Value to cast
+	 * @return CVMBigDecimal value, or null if not convertible
+	 */
+	public static CVMBigDecimal ensureBigDecimal(ACell a) {
+		if (a instanceof CVMBigDecimal) return (CVMBigDecimal) a;
+		if (a instanceof CVMLong l) return CVMBigDecimal.fromLong(l.longValue());
+		if (a instanceof AInteger ai) return CVMBigDecimal.fromBigInteger(ai.big());
+		if (a instanceof CVMDouble d) return CVMBigDecimal.fromDouble(d.doubleValue());
 		return null;
 	}
 


### PR DESCRIPTION
## Summary

Implements arbitrary-precision decimal arithmetic for the CVM numeric tower, fulfilling bounty #5.

### Changes

- **CVMBigDecimal.java**: Wraps `java.math.BigDecimal`, extends `ANumeric`
  - Exact decimal arithmetic (add, sub, multiply, divide)
  - Type promotion: `Decimal op Integer → Decimal`, `Decimal op Double → Double`
  - CAD3 encoding: tag `0x1a` + VLQ signed scale + VLQ byte count + unscaled bytes
  - Canonical if and only if value has meaningful fractional digits (integers stay as Long/BigInteger)

- **Decimal.java**: Type class for `CVMBigDecimal` registered as `Types.DECIMAL`

- **Core.java**: Registers `bigdecimal` (code 260) constructor and `bigdecimal?` (code 261) predicate

- **CAD3Encoder.java**: Decodes tag `0x1a` → reads VLQ scale, VLQ byte count, unscaled bytes → constructs `CVMBigDecimal`

- **Juice.java**: `costNumeric()` charges proportional to unscaled byte length (same as BigInteger)

- **RT.java**: `ensureBigDecimal()` conversion from any numeric type

- **Tag.java**: `BIG_DECIMAL = 0x1a`
- **Symbols.java**: `BIGDECIMAL`, `BIGDECIMAL_Q`

### Design Decisions

- **Code 260** for `bigdecimal` constructor, **261** for `bigdecimal?` predicate
- **Tag 0x1a** for wire format (between BIG_INTEGER=0x19 and DOUBLE=0x1D)
- **Canonicality**: Only decimals with fractional digits are canonical; integers always reduce to CVMLong/CVMBigInteger
- **Division**: Non-terminating decimal division throws `ArithmeticException` (preserves exactness)
- **Numeric dispatch**: CVMBigDecimal handles Integer operands directly; falls back to Double for CVMDouble operands

Fixes #5
