### PR TITLE
Upgrade Javalin to 7.2.2

### DIFF
--- a/convex-dlfs/src/main/java/convex/dlfs/DLFSServer.java
+++ b/convex-dlfs/src/main/java/convex/dlfs/DLFSServer.java
@@ -15,6 +15,7 @@ import convex.core.data.Maps;
 import convex.core.util.Utils;
 import convex.peer.auth.PeerAuth;
 import convex.restapi.auth.AuthMiddleware;
+import convex.restapi.handler.HttpMethodFilter;
 import convex.restapi.mcp.McpServer;
 import io.javalin.Javalin;
 import io.javalin.config.RoutesConfig;
@@ -88,6 +89,8 @@ public class DLFSServer implements Closeable {
 				cors.addRule(corsConfig -> corsConfig.anyHost());
 			});
 			config.concurrency.useVirtualThreads = true;
+
+			HttpMethodFilter.install(config);
 
 			// Configure Jetty connector with minimal platform threads.
 			// Request handling uses virtual threads (useVirtualThreads=true above),

--- a/convex-dlfs/src/main/java/convex/dlfs/DLFSServer.java
+++ b/convex-dlfs/src/main/java/convex/dlfs/DLFSServer.java
@@ -17,6 +17,7 @@ import convex.peer.auth.PeerAuth;
 import convex.restapi.auth.AuthMiddleware;
 import convex.restapi.mcp.McpServer;
 import io.javalin.Javalin;
+import io.javalin.config.RoutesConfig;
 
 /**
  * Standalone DLFS WebDAV server with multi-drive support.
@@ -86,44 +87,47 @@ public class DLFSServer implements Closeable {
 			config.bundledPlugins.enableCors(cors -> {
 				cors.addRule(corsConfig -> corsConfig.anyHost());
 			});
-			config.useVirtualThreads = true;
+			config.concurrency.useVirtualThreads = true;
+
+			// Configure Jetty connector with minimal platform threads.
+			// Request handling uses virtual threads (useVirtualThreads=true above),
+			// so we only need 1 acceptor + 1 selector for the connector.
+			config.jetty.addConnector((jettyServer, httpConfig) -> {
+				ServerConnector connector = new ServerConnector(jettyServer, 1, 1);
+				connector.setPort(port);
+				return connector;
+			});
+
+			RoutesConfig routes = config.routes;
+
+			// Wire auth middleware if key pair provided (with audience checking)
+			if (keyPair != null) {
+				PeerAuth peerAuth = PeerAuth.createWithDIDAudience(keyPair);
+				AuthMiddleware auth = new AuthMiddleware(peerAuth);
+				routes.before(auth.handler());
+			}
+
+			// Request/response logging
+			routes.before(ctx -> {
+				if (!log.isDebugEnabled()) return;
+				String method = ctx.req().getMethod();
+				String uri = ctx.req().getRequestURI();
+				String dest = ctx.header("Destination");
+				String depth = ctx.header("Depth");
+				StringBuilder sb = new StringBuilder();
+				sb.append("--> ").append(method).append(" ").append(uri);
+				if (dest != null) sb.append("  Destination: ").append(dest);
+				if (depth != null) sb.append("  Depth: ").append(depth);
+				log.debug(sb.toString());
+			});
+			routes.after(ctx -> {
+				log.debug("<-- {} {} {}", ctx.status(), ctx.req().getMethod(), ctx.req().getRequestURI());
+			});
+
+			// Register WebDAV and MCP routes
+			webdav.addRoutes(routes);
+			mcpServer.addRoutes(routes);
 		});
-
-		// Wire auth middleware if key pair provided (with audience checking)
-		if (keyPair != null) {
-			PeerAuth peerAuth = PeerAuth.createWithDIDAudience(keyPair);
-			AuthMiddleware auth = new AuthMiddleware(peerAuth);
-			app.before(auth.handler());
-		}
-
-		// Request/response logging
-		app.before(ctx -> {
-			if (!log.isDebugEnabled()) return;
-			String method = ctx.req().getMethod();
-			String uri = ctx.req().getRequestURI();
-			String dest = ctx.header("Destination");
-			String depth = ctx.header("Depth");
-			StringBuilder sb = new StringBuilder();
-			sb.append("--> ").append(method).append(" ").append(uri);
-			if (dest != null) sb.append("  Destination: ").append(dest);
-			if (depth != null) sb.append("  Depth: ").append(depth);
-			log.debug(sb.toString());
-		});
-		app.after(ctx -> {
-			log.debug("<-- {} {} {}", ctx.status(), ctx.req().getMethod(), ctx.req().getRequestURI());
-		});
-
-		// Register WebDAV and MCP routes
-		webdav.addRoutes(app);
-		mcpServer.addRoutes(app);
-
-		// Configure Jetty connector with minimal platform threads.
-		// Request handling uses virtual threads (useVirtualThreads=true above),
-		// so we only need 1 acceptor + 1 selector for the connector.
-		org.eclipse.jetty.server.Server jettyServer = app.jettyServer().server();
-		ServerConnector connector = new ServerConnector(jettyServer, 1, 1);
-		connector.setPort(port);
-		jettyServer.addConnector(connector);
 
 		app.start();
 	}

--- a/convex-dlfs/src/main/java/convex/dlfs/DLFSWebDAV.java
+++ b/convex-dlfs/src/main/java/convex/dlfs/DLFSWebDAV.java
@@ -17,8 +17,10 @@ import java.util.List;
 
 import convex.lattice.fs.DLFileSystem;
 import convex.restapi.auth.AuthMiddleware;
-import io.javalin.Javalin;
+import io.javalin.config.RoutesConfig;
 import io.javalin.http.Context;
+import io.javalin.http.Handler;
+import io.javalin.http.HandlerType;
 
 /**
  * WebDAV-compatible HTTP handler with multi-drive support.
@@ -64,60 +66,51 @@ public class DLFSWebDAV {
 		return this;
 	}
 
+	// Custom WebDAV HTTP methods, supported natively by Javalin 7+
+	private static final HandlerType PROPFIND = HandlerType.findOrCreate("PROPFIND");
+	private static final HandlerType PROPPATCH = HandlerType.findOrCreate("PROPPATCH");
+	private static final HandlerType MKCOL = HandlerType.findOrCreate("MKCOL");
+	private static final HandlerType MOVE = HandlerType.findOrCreate("MOVE");
+	private static final HandlerType COPY = HandlerType.findOrCreate("COPY");
+	private static final HandlerType LOCK = HandlerType.findOrCreate("LOCK");
+	private static final HandlerType UNLOCK = HandlerType.findOrCreate("UNLOCK");
+
 	/**
-	 * Registers WebDAV routes on the given Javalin app.
+	 * Registers WebDAV routes on the given routes configuration.
 	 */
-	public void addRoutes(Javalin app) {
-		app.get(ROUTE_PATH, this::handleGet);
-		app.get(ROUTE, this::handleGet);
-		app.put(ROUTE_PATH, this::handlePut);
-		app.delete(ROUTE_PATH, this::handleDelete);
-		app.head(ROUTE_PATH, this::handleHead);
-		app.head(ROUTE, this::handleHead);
-		app.head(ROUTE_BARE, this::handleHead);
-		app.options(ROUTE_PATH, this::handleOptions);
-		app.options(ROUTE, this::handleOptions);
-		app.options(ROUTE_BARE, this::handleOptions);
+	public void addRoutes(RoutesConfig routes) {
+		routes.get(ROUTE_PATH, this::handleGet);
+		routes.get(ROUTE, this::handleGet);
+		routes.put(ROUTE_PATH, this::handlePut);
+		routes.delete(ROUTE_PATH, this::handleDelete);
+		routes.head(ROUTE_PATH, this::handleHead);
+		routes.head(ROUTE, this::handleHead);
+		routes.head(ROUTE_BARE, this::handleHead);
+		routes.options(ROUTE_PATH, this::handleOptions);
+		routes.options(ROUTE, this::handleOptions);
+		routes.options(ROUTE_BARE, this::handleOptions);
 
 		// Root-level DAV discovery (Windows WebClient sends OPTIONS / then PROPFIND /)
-		app.options("/", this::handleOptions);
-		app.before(ctx -> {
-			if ("PROPFIND".equals(ctx.req().getMethod()) && "/".equals(ctx.path())) {
-				handleRootPropfind(ctx);
-				ctx.skipRemainingHandlers();
-				return;
-			}
-		});
+		routes.options("/", this::handleOptions);
+		routes.addHttpHandler(PROPFIND, "/", this::handleRootPropfind);
 
-		// Custom WebDAV methods — Javalin has no built-in handler type for these
-		app.before(ctx -> {
-			String method = ctx.req().getMethod();
-			String uri = ctx.req().getRequestURI();
-			if (!uri.startsWith(ROUTE_BARE)) return;
+		// Custom WebDAV methods on the DLFS paths
+		addDLFSMethod(routes, PROPFIND, this::handlePropfind);
+		addDLFSMethod(routes, MKCOL, this::handleMkcol);
+		addDLFSMethod(routes, MOVE, this::handleMove);
+		addDLFSMethod(routes, COPY, this::handleCopy);
+		addDLFSMethod(routes, PROPPATCH, this::handleProppatch);
+		addDLFSMethod(routes, LOCK, this::handleLock);
+		addDLFSMethod(routes, UNLOCK, ctx -> ctx.status(204));
+	}
 
-			if ("PROPFIND".equals(method)) {
-				handlePropfind(ctx);
-				ctx.skipRemainingHandlers();
-			} else if ("MKCOL".equals(method)) {
-				handleMkcol(ctx);
-				ctx.skipRemainingHandlers();
-			} else if ("MOVE".equals(method)) {
-				handleMove(ctx);
-				ctx.skipRemainingHandlers();
-			} else if ("COPY".equals(method)) {
-				handleCopy(ctx);
-				ctx.skipRemainingHandlers();
-			} else if ("PROPPATCH".equals(method)) {
-				handleProppatch(ctx);
-				ctx.skipRemainingHandlers();
-			} else if ("LOCK".equals(method)) {
-				handleLock(ctx);
-				ctx.skipRemainingHandlers();
-			} else if ("UNLOCK".equals(method)) {
-				ctx.status(204);
-				ctx.skipRemainingHandlers();
-			}
-		});
+	/**
+	 * Registers a handler for a WebDAV method on all DLFS path forms.
+	 */
+	private static void addDLFSMethod(RoutesConfig routes, HandlerType method, Handler handler) {
+		routes.addHttpHandler(method, ROUTE_BARE, handler);
+		routes.addHttpHandler(method, ROUTE, handler);
+		routes.addHttpHandler(method, ROUTE_PATH, handler);
 	}
 
 	// ==================== Path Resolution ====================

--- a/convex-dlfs/src/main/java/convex/dlfs/DLFSWebDAV.java
+++ b/convex-dlfs/src/main/java/convex/dlfs/DLFSWebDAV.java
@@ -134,11 +134,11 @@ public class DLFSWebDAV {
 	DrivePath parseDrivePath(Context ctx) {
 		String pathParam = null;
 
-		// Try Javalin path param first (standard routes, already URL-decoded)
+		// Try Javalin path param first (routes registered on ROUTE_PATH, already URL-decoded)
 		try {
 			pathParam = ctx.pathParam("path");
 		} catch (Exception e) {
-			// not available (custom methods in before handler)
+			// not available (bare /dlfs routes have no path param)
 		}
 
 		// Fall back to URI extraction

--- a/convex-dlfs/src/test/java/convex/dlfs/test/DLFSServerTest.java
+++ b/convex-dlfs/src/test/java/convex/dlfs/test/DLFSServerTest.java
@@ -41,6 +41,29 @@ public class DLFSServerTest {
 	}
 
 	@Test
+	void testMalformedMethodRejected() throws Exception {
+		// Method tokens Javalin cannot route (hyphenated/lowercase) → 400, not 500
+		HttpRequest hyphenated = HttpRequest.newBuilder()
+				.uri(URI.create(driveURL))
+				.method("M-SEARCH", HttpRequest.BodyPublishers.noBody())
+				.build();
+		assertEquals(400, client.send(hyphenated, HttpResponse.BodyHandlers.ofString()).statusCode());
+
+		HttpRequest lowercase = HttpRequest.newBuilder()
+				.uri(URI.create(driveURL))
+				.method("propfind", HttpRequest.BodyPublishers.noBody())
+				.build();
+		assertEquals(400, client.send(lowercase, HttpResponse.BodyHandlers.ofString()).statusCode());
+
+		// Well-formed but unknown method falls through to normal routing → 404
+		HttpRequest unknown = HttpRequest.newBuilder()
+				.uri(URI.create(baseURL + "no-such-place"))
+				.method("FOOBAR", HttpRequest.BodyPublishers.noBody())
+				.build();
+		assertEquals(404, client.send(unknown, HttpResponse.BodyHandlers.ofString()).statusCode());
+	}
+
+	@Test
 	void testPutAndGetRoundTrip() throws Exception {
 		String content = "Hello DLFS!";
 		String path = driveURL + "test.txt";

--- a/convex-dlfs/src/test/java/convex/dlfs/test/DLFSServerTest.java
+++ b/convex-dlfs/src/test/java/convex/dlfs/test/DLFSServerTest.java
@@ -42,18 +42,18 @@ public class DLFSServerTest {
 
 	@Test
 	void testMalformedMethodRejected() throws Exception {
-		// Method tokens Javalin cannot route (hyphenated/lowercase) → 400, not 500
+		// Method tokens Javalin cannot route (hyphenated/lowercase) → 501, not 500
 		HttpRequest hyphenated = HttpRequest.newBuilder()
 				.uri(URI.create(driveURL))
 				.method("M-SEARCH", HttpRequest.BodyPublishers.noBody())
 				.build();
-		assertEquals(400, client.send(hyphenated, HttpResponse.BodyHandlers.ofString()).statusCode());
+		assertEquals(501, client.send(hyphenated, HttpResponse.BodyHandlers.ofString()).statusCode());
 
 		HttpRequest lowercase = HttpRequest.newBuilder()
 				.uri(URI.create(driveURL))
 				.method("propfind", HttpRequest.BodyPublishers.noBody())
 				.build();
-		assertEquals(400, client.send(lowercase, HttpResponse.BodyHandlers.ofString()).statusCode());
+		assertEquals(501, client.send(lowercase, HttpResponse.BodyHandlers.ofString()).statusCode());
 
 		// Well-formed but unknown method falls through to normal routing → 404
 		HttpRequest unknown = HttpRequest.newBuilder()

--- a/convex-restapi/pom.xml
+++ b/convex-restapi/pom.xml
@@ -16,7 +16,7 @@
 
 	<properties>
 		<json.simple.version>1.1.1</json.simple.version>
-		<javalin.version>6.7.0</javalin.version>
+		<javalin.version>7.2.2</javalin.version>
 	</properties>
 
 	<build>

--- a/convex-restapi/src/main/java/convex/restapi/RESTServer.java
+++ b/convex-restapi/src/main/java/convex/restapi/RESTServer.java
@@ -2,7 +2,6 @@ package convex.restapi;
 
 import java.io.Closeable;
 import java.util.HashMap;
-import java.util.function.Consumer;
 
 import org.eclipse.jetty.server.ServerConnector;
 import org.slf4j.Logger;
@@ -53,7 +52,6 @@ import io.javalin.http.HttpResponseException;
 import io.javalin.http.staticfiles.Location;
 import io.javalin.openapi.JsonSchemaLoader;
 import io.javalin.openapi.JsonSchemaResource;
-import io.javalin.openapi.OpenApiInfo;
 import io.javalin.openapi.plugin.OpenApiPlugin;
 import io.javalin.openapi.plugin.redoc.ReDocPlugin;
 import io.javalin.openapi.plugin.swagger.SwaggerPlugin;
@@ -197,7 +195,7 @@ public class RESTServer implements Closeable {
 		authPage.addRoutes(routes);
 	}
 	
-	private Javalin buildApp(boolean useSSL, Integer port) {
+	private Javalin buildApp(Integer port) {
 		int bindPort = (port == null) ? DEFAULT_PORT : port;
 		Javalin app = Javalin.create(config -> {
 			config.bundledPlugins.enableCors(cors -> {
@@ -303,11 +301,10 @@ public class RESTServer implements Closeable {
             pluginConfig
             .withDocumentationPath(docsPath)
             .withDefinitionConfiguration((version, schema) -> {
-                schema.info((Consumer <OpenApiInfo>)
-                		info -> {
-							info.title("Convex REST API");
-							info.version(Utils.getVersion());
-		                });
+                schema.info(info -> {
+					info.title("Convex REST API");
+					info.version(Utils.getVersion());
+                });
             });
 		}));
 
@@ -318,9 +315,11 @@ public class RESTServer implements Closeable {
 	        reDocConfiguration.documentationPath = docsPath;
 	    }));
 		
-		for (JsonSchemaResource generatedJsonSchema : new JsonSchemaLoader().loadGeneratedSchemes()) {
-	        System.out.println(generatedJsonSchema.getName());
-	    }
+		if (log.isDebugEnabled()) {
+			for (JsonSchemaResource generatedJsonSchema : new JsonSchemaLoader().loadGeneratedSchemes()) {
+				log.debug("Loaded JSON schema: {}", generatedJsonSchema.getName());
+			}
+		}
 	}
 
 
@@ -361,14 +360,14 @@ public class RESTServer implements Closeable {
 	public synchronized void start(Integer port) {
 		close();
 		try {
-			javalin=buildApp(true,port);
+			javalin=buildApp(port);
 			javalin.start();
 		} catch (JavalinException e) {
 			if (port!=null) throw e; // only try again if port unspecified
 			log.warn("Default port "+DEFAULT_PORT+" already in use, chosing another at random");
 			close();
 
-			javalin=buildApp(false,0); // use random port
+			javalin=buildApp(0); // use random port
 			javalin.start();
 		}
 	}

--- a/convex-restapi/src/main/java/convex/restapi/RESTServer.java
+++ b/convex-restapi/src/main/java/convex/restapi/RESTServer.java
@@ -37,6 +37,7 @@ import convex.restapi.api.X402;
 import convex.restapi.auth.AuthMiddleware;
 import convex.restapi.auth.ConfirmationService;
 import convex.restapi.auth.OAuthService;
+import convex.restapi.handler.HttpMethodFilter;
 import convex.restapi.mcp.McpAPI;
 import convex.restapi.mcp.McpServer;
 import convex.restapi.web.AuthPage;
@@ -221,6 +222,8 @@ public class RESTServer implements Closeable {
 			});
 
 			config.concurrency.useVirtualThreads=true;
+
+			HttpMethodFilter.install(config);
 
 			config.jetty.addConnector((jettyServer, httpConfig) -> {
 				// 1 acceptor + 1 selector: request handling uses virtual threads

--- a/convex-restapi/src/main/java/convex/restapi/RESTServer.java
+++ b/convex-restapi/src/main/java/convex/restapi/RESTServer.java
@@ -55,7 +55,7 @@ import io.javalin.openapi.JsonSchemaResource;
 import io.javalin.openapi.plugin.OpenApiPlugin;
 import io.javalin.openapi.plugin.redoc.ReDocPlugin;
 import io.javalin.openapi.plugin.swagger.SwaggerPlugin;
-import io.javalin.util.JavalinException;
+import io.javalin.util.JavalinBindException;
 
 /**
  * Operates a REST API server and web application connected to a local peer server
@@ -362,9 +362,9 @@ public class RESTServer implements Closeable {
 		try {
 			javalin=buildApp(port);
 			javalin.start();
-		} catch (JavalinException e) {
+		} catch (JavalinBindException e) {
 			if (port!=null) throw e; // only try again if port unspecified
-			log.warn("Default port "+DEFAULT_PORT+" already in use, chosing another at random");
+			log.warn("Default port "+DEFAULT_PORT+" already in use ("+e.getMessage()+"), choosing another at random");
 			close();
 
 			javalin=buildApp(0); // use random port

--- a/convex-restapi/src/main/java/convex/restapi/RESTServer.java
+++ b/convex-restapi/src/main/java/convex/restapi/RESTServer.java
@@ -48,12 +48,12 @@ import convex.api.ContentTypes;
 import convex.core.util.JSON;
 import io.javalin.Javalin;
 import io.javalin.config.JavalinConfig;
+import io.javalin.config.RoutesConfig;
 import io.javalin.http.HttpResponseException;
 import io.javalin.http.staticfiles.Location;
 import io.javalin.openapi.JsonSchemaLoader;
 import io.javalin.openapi.JsonSchemaResource;
 import io.javalin.openapi.OpenApiInfo;
-import io.javalin.openapi.plugin.DefinitionConfiguration;
 import io.javalin.openapi.plugin.OpenApiPlugin;
 import io.javalin.openapi.plugin.redoc.ReDocPlugin;
 import io.javalin.openapi.plugin.swagger.SwaggerPlugin;
@@ -148,32 +148,32 @@ public class RESTServer implements Closeable {
 		return oauthService;
 	}
 
-	private void addAPIRoutes(Javalin app) {
+	private void addAPIRoutes(RoutesConfig routes) {
 		// Auth middleware — extracts identity from bearer token if present
 		AKeyPair peerKP = server.getKeyPair();
 		if (peerKP != null) {
 			PeerAuth peerAuth = new PeerAuth(peerKP);
 			authMiddleware = new AuthMiddleware(peerAuth);
-			app.before(authMiddleware.handler());
+			routes.before(authMiddleware.handler());
 		}
 
 		chainAPI = new ChainAPI(this);
-		chainAPI.addRoutes(app);
+		chainAPI.addRoutes(routes);
 
 		depAPI = new DepAPI(this);
-		depAPI.addRoutes(app);
+		depAPI.addRoutes(routes);
 		
 		peerAPI = new PeerAdminAPI(this);
-		peerAPI.addRoutes(app);
+		peerAPI.addRoutes(routes);
 
 		webApp = new WebApp(this);
-		webApp.addRoutes(app);
+		webApp.addRoutes(routes);
 
 		dlAPI = new DLAPI(this);
-		dlAPI.addRoutes(app);
+		dlAPI.addRoutes(routes);
 
 		explorerAPI = new ExplorerAPI(this);
-		explorerAPI.addRoutes(app);
+		explorerAPI.addRoutes(routes);
 
 		mcpServer = new McpServer(Maps.of(
 			"name", "convex-mcp",
@@ -181,56 +181,65 @@ public class RESTServer implements Closeable {
 			"version", Utils.getVersion()
 		));
 		mcpAPI = new McpAPI(this, mcpServer);
-		mcpServer.addRoutes(app);
-		mcpAPI.addRoutes(app);
+		mcpServer.addRoutes(routes);
+		mcpAPI.addRoutes(routes);
 
 		x402API = new X402(this);
-		x402API.addRoutes(app);
+		x402API.addRoutes(routes);
 
 		didAPI = new DIDAPI(this);
-		didAPI.addRoutes(app);
+		didAPI.addRoutes(routes);
 
 		confirmAPI = new ConfirmAPI(this);
-		confirmAPI.addRoutes(app);
+		confirmAPI.addRoutes(routes);
 
 		authPage = new AuthPage(this);
-		authPage.addRoutes(app);
+		authPage.addRoutes(routes);
 	}
 	
-	private Javalin buildApp(boolean useSSL) {
+	private Javalin buildApp(boolean useSSL, Integer port) {
+		int bindPort = (port == null) ? DEFAULT_PORT : port;
 		Javalin app = Javalin.create(config -> {
 			config.bundledPlugins.enableCors(cors -> {
 				cors.addRule(corsConfig -> {
 					// ?? corsConfig.allowCredentials=true;
-					
+
 					// replacement for enableCorsForAllOrigins()
 					corsConfig.anyHost();
 				});
 			});
-			
-			
+
+
 			addOpenApiPlugins(config);
 
 			config.staticFiles.add(staticFiles -> {
 				staticFiles.hostedPath = "/";
 				staticFiles.location = Location.CLASSPATH; // Specify resources from classpath
 				staticFiles.directory = "/convex/restapi/pub"; // Resource location in classpath
-				staticFiles.precompress = false; // if the files should be pre-compressed and cached in memory
-													// (optimization)
 				staticFiles.aliasCheck = null; // you can configure this to enable symlinks (=
 												// ContextHandler.ApproveAliases())
 				staticFiles.skipFileFunction = req -> false; // you can use this to skip certain files in the dir, based
 																// on the HttpServletRequest
 			});
-			
-			config.useVirtualThreads=true;
+
+			config.concurrency.useVirtualThreads=true;
+
+			config.jetty.addConnector((jettyServer, httpConfig) -> {
+				// 1 acceptor + 1 selector: request handling uses virtual threads
+				ServerConnector connector = new ServerConnector(jettyServer, 1, 1);
+				connector.setPort(bindPort);
+				return connector;
+			});
+
+			addHandlers(config.routes);
 		});
-		
+		return app;
+	}
 
-
+	private void addHandlers(RoutesConfig routes) {
 		// Custom handler for HTTP error responses (BadRequestResponse, NotFoundResponse, etc.)
 		// Produces consistent output in the requested content type: {:error "message"} or {"error":"message"}
-		app.exception(HttpResponseException.class, (e, ctx) -> {
+		routes.exception(HttpResponseException.class, (e, ctx) -> {
 			ctx.status(e.getStatus());
 			String msg=e.getMessage();
 			if (msg==null) msg="Error";
@@ -254,15 +263,15 @@ public class RESTServer implements Closeable {
 			}
 		});
 
-		app.exception(Exception.class, (e, ctx) -> {
+		routes.exception(Exception.class, (e, ctx) -> {
 			e.printStackTrace();
 			String message = "Unexpected error: " + e;
 			ctx.result(message);
 			ctx.status(500);
 		});
-		
-		
-		app.options("/*", ctx-> {
+
+
+		routes.options("/*", ctx-> {
 			ctx.status(204); // No context#
 			ctx.removeHeader("Content-type");
 			ctx.header("access-control-allow-headers", "content-type");
@@ -272,7 +281,7 @@ public class RESTServer implements Closeable {
 		});
 		
 		// Header to every response
-		app.afterMatched(ctx->{
+		routes.afterMatched(ctx->{
 			// Reflect CORS origin
 			String origin = ctx.req().getHeader("Origin");
 			if (origin!=null) {
@@ -282,8 +291,7 @@ public class RESTServer implements Closeable {
 			}
 		});
 
-		addAPIRoutes(app);	
-		return app;
+		addAPIRoutes(routes);
 	}
 
 
@@ -294,21 +302,20 @@ public class RESTServer implements Closeable {
 		config.registerPlugin(new OpenApiPlugin(pluginConfig -> {
             pluginConfig
             .withDocumentationPath(docsPath)
-            .withDefinitionConfiguration((version, definition) -> {
-            	DefinitionConfiguration def=definition;
-                def=def.withInfo((Consumer <OpenApiInfo>)
+            .withDefinitionConfiguration((version, schema) -> {
+                schema.info((Consumer <OpenApiInfo>)
                 		info -> {
-							info.setTitle("Convex REST API");
-							info.setVersion(Utils.getVersion());
+							info.title("Convex REST API");
+							info.version(Utils.getVersion());
 		                });
             });
 		}));
 
 		config.registerPlugin(new SwaggerPlugin(swaggerConfiguration->{
-			swaggerConfiguration.setDocumentationPath(docsPath);
+			swaggerConfiguration.documentationPath = docsPath;
 		}));
 		config.registerPlugin(new ReDocPlugin(reDocConfiguration -> {
-	        reDocConfiguration.setDocumentationPath(docsPath);
+	        reDocConfiguration.documentationPath = docsPath;
 	    }));
 		
 		for (JsonSchemaResource generatedJsonSchema : new JsonSchemaLoader().loadGeneratedSchemes()) {
@@ -341,14 +348,6 @@ public class RESTServer implements Closeable {
 		return create(convex.getLocalServer());
 	}
 	
-	protected void setupJettyServer(org.eclipse.jetty.server.Server jettyServer, Integer port) {
-		if (port==null) port=DEFAULT_PORT;
-		// 1 acceptor + 1 selector: request handling uses virtual threads
-		ServerConnector connector = new ServerConnector(jettyServer, 1, 1);
-		connector.setPort(port);
-		jettyServer.addConnector(connector);
-	}
-
 	/**
 	 * Start app with default port
 	 */
@@ -362,23 +361,16 @@ public class RESTServer implements Closeable {
 	public synchronized void start(Integer port) {
 		close();
 		try {
-			javalin=buildApp(true);
-			start(javalin,port);
+			javalin=buildApp(true,port);
+			javalin.start();
 		} catch (JavalinException e) {
 			if (port!=null) throw e; // only try again if port unspecified
-			log.warn("Specified port "+port+"already in use, chosing another at random");
+			log.warn("Default port "+DEFAULT_PORT+" already in use, chosing another at random");
 			close();
-			
-			port=0; // use random port
-			javalin=buildApp(false);
-			start(javalin,port);
+
+			javalin=buildApp(false,0); // use random port
+			javalin.start();
 		}
-	}
-	
-	protected void start(Javalin app, Integer port) {
-		org.eclipse.jetty.server.Server jettyServer=app.jettyServer().server();
-		setupJettyServer(jettyServer,port);
-		app.start();
 	}
 
 	public synchronized void close() {

--- a/convex-restapi/src/main/java/convex/restapi/api/AGenericAPI.java
+++ b/convex-restapi/src/main/java/convex/restapi/api/AGenericAPI.java
@@ -25,7 +25,7 @@ import convex.core.json.JSONReader;
 import convex.core.lang.RT;
 import convex.core.lang.Reader;
 import convex.core.util.JSON;
-import io.javalin.Javalin;
+import io.javalin.config.RoutesConfig;
 import io.javalin.http.BadRequestResponse;
 import io.javalin.http.Context;
 
@@ -37,9 +37,9 @@ public abstract class AGenericAPI {
 
 	/**
 	 * Add routes to the service
-	 * @param app Javalin instance to add routes to
+	 * @param routes Routes configuration to add routes to
 	 */
-	public abstract void addRoutes(Javalin app);
+	public abstract void addRoutes(RoutesConfig routes);
 	
 	public static String calcResponseContentType(Context ctx) {
 		Enumeration<String> accepts=ctx.req().getHeaders("Accept");

--- a/convex-restapi/src/main/java/convex/restapi/api/ChainAPI.java
+++ b/convex-restapi/src/main/java/convex/restapi/api/ChainAPI.java
@@ -71,7 +71,7 @@ import convex.restapi.model.TransactRequest;
 import convex.restapi.model.TransactionPrepareRequest;
 import convex.restapi.model.TransactionPrepareResponse;
 import convex.restapi.model.TransactionSubmitRequest;
-import io.javalin.Javalin;
+import io.javalin.config.RoutesConfig;
 import io.javalin.http.BadRequestResponse;
 import io.javalin.http.Context;
 import io.javalin.http.ForbiddenResponse;
@@ -101,38 +101,38 @@ public class ChainAPI extends ABaseAPI {
 	private ConcurrentLimit transactLimit=new ConcurrentLimit(2);
 	
 	@Override
-	public void addRoutes(Javalin app) {
+	public void addRoutes(RoutesConfig routes) {
 		String prefix = ROUTE;
 
-		app.post(prefix + "query", this::query);
+		routes.post(prefix + "query", this::query);
 
-		app.post(prefix + "transaction/prepare", this::transactionPrepare);
-		app.post(prefix + "transaction/submit", this::transactionSubmit);
-		app.post(prefix + "transact", transactLimit.handler(this::transact));
+		routes.post(prefix + "transaction/prepare", this::transactionPrepare);
+		routes.post(prefix + "transaction/submit", this::transactionSubmit);
+		routes.post(prefix + "transact", transactLimit.handler(this::transact));
 
-		app.post(prefix + "createAccount", faucetLimit.handler(this::createAccount));
-		app.post(prefix + "faucet",  faucetLimit.handler(this::faucetRequest));
+		routes.post(prefix + "createAccount", faucetLimit.handler(this::createAccount));
+		routes.post(prefix + "faucet",  faucetLimit.handler(this::faucetRequest));
 
 
-		app.get(prefix + "accounts/{addr}", this::queryAccount);
-		app.get(prefix + "peers/{addr}", this::queryPeer);
+		routes.get(prefix + "accounts/{addr}", this::queryAccount);
+		routes.get(prefix + "peers/{addr}", this::queryPeer);
 
 	
-		app.get(prefix + "data/{hash}", this::getData);
-		app.post(prefix + "data/encode", this::encodeData);
-		app.post(prefix + "data/decode", this::decodeData);
+		routes.get(prefix + "data/{hash}", this::getData);
+		routes.post(prefix + "data/encode", this::encodeData);
+		routes.post(prefix + "data/decode", this::decodeData);
 		
 		
-		app.get(prefix + "tx", this::getTransaction);
+		routes.get(prefix + "tx", this::getTransaction);
 		
-		app.get(prefix + "blocks", this::getBlocks);
-		app.get(prefix + "blocks/{blockNum}", this::getBlock);
+		routes.get(prefix + "blocks", this::getBlocks);
+		routes.get(prefix + "blocks/{blockNum}", this::getBlock);
 		
-		app.get(prefix + "status", this::getStatus);
+		routes.get(prefix + "status", this::getStatus);
 
-		app.post(prefix + "message", this::handleMessage);
+		routes.post(prefix + "message", this::handleMessage);
 
-		app.get("/identicon/{hex}", identiconLimit.handler(this::getIdenticon));
+		routes.get("/identicon/{hex}", identiconLimit.handler(this::getIdenticon));
 	}
 
 	@OpenApi(path = ROUTE + "data/{hash}", 

--- a/convex-restapi/src/main/java/convex/restapi/api/ChainAPI.java
+++ b/convex-restapi/src/main/java/convex/restapi/api/ChainAPI.java
@@ -136,7 +136,6 @@ public class ChainAPI extends ABaseAPI {
 	}
 
 	@OpenApi(path = ROUTE + "data/{hash}", 
-			versions="peer-v1",
 			methods = HttpMethod.GET, 
 			tags = { "Data Lattice"},
 			summary = "Get data from the server with the specified hash", 
@@ -167,7 +166,6 @@ public class ChainAPI extends ABaseAPI {
 	}
 	
 	@OpenApi(path = ROUTE + "data/encode", 
-			versions="peer-v1",
 			methods = HttpMethod.POST, 
 			tags = { "Data Lattice"},
 			summary = "Encode data in CAD3 multi-cell format", 
@@ -226,7 +224,6 @@ public class ChainAPI extends ABaseAPI {
 	}
 	
 	@OpenApi(path = ROUTE + "data/decode", 
-			versions="peer-v1",
 			methods = HttpMethod.POST, 
 			tags = { "Data Lattice"},
 			summary = "Decode CAD3 data", 
@@ -277,7 +274,6 @@ public class ChainAPI extends ABaseAPI {
 	}
 
 	@OpenApi(path = ROUTE + "tx", 
-			versions="peer-v1",
 			methods = HttpMethod.GET, 
 			tags = { "Transactions"},
 			summary = "Get transaction by hash", 
@@ -335,7 +331,6 @@ public class ChainAPI extends ABaseAPI {
 	}
 
 	@OpenApi(path = ROUTE + "blocks", 
-			versions="peer-v1",
 			methods = HttpMethod.GET, 
 			tags = { "Blocks"},
 			summary = "Get blocks with pagination", 
@@ -440,7 +435,6 @@ public class ChainAPI extends ABaseAPI {
 	}
 
 	@OpenApi(path = ROUTE + "blocks/{blockNum}", 
-			versions="peer-v1",
 			methods = HttpMethod.GET, 
 			tags = { "Blocks"},
 			summary = "Get a specific block by block number", 
@@ -504,7 +498,6 @@ public class ChainAPI extends ABaseAPI {
 	}
 
 	@OpenApi(path = ROUTE + "status", 
-			versions="peer-v1",
 			methods = HttpMethod.GET, 
 			tags = { "Peer"},
 			summary = "Get the status map from the peer server. Can be used as a heartbeat check to ensure the peer is still running.", 
@@ -557,7 +550,6 @@ public class ChainAPI extends ABaseAPI {
 	}
 
 	@OpenApi(path = ROUTE + "createAccount", 
-			versions="peer-v1",
 			methods = HttpMethod.POST, 
 			operationId = "createAccount", 
 			tags = { "Account"},
@@ -612,7 +604,6 @@ public class ChainAPI extends ABaseAPI {
 	}
 
 	@OpenApi(path = ROUTE + "accounts/{address}", 
-			versions="peer-v1",
 			methods = HttpMethod.GET, 
 			operationId = "queryAccount", 
 			tags = { "Account"},
@@ -706,7 +697,6 @@ public class ChainAPI extends ABaseAPI {
 	public static final Keyword K_FAUCET=Keyword.intern("faucet");
 	
 	@OpenApi(path = ROUTE + "faucet", 
-			versions="peer-v1",
 			methods = HttpMethod.POST, 
 			operationId = "faucetRequest", 
 			tags = { "Account"},
@@ -777,7 +767,6 @@ public class ChainAPI extends ABaseAPI {
 
 
 	@OpenApi(path = ROUTE+"transaction/prepare",
-			versions="peer-v1",
 			methods = HttpMethod.POST,
 			operationId = "transactionPrepare",
 			tags= {"Transactions"},
@@ -852,7 +841,6 @@ public class ChainAPI extends ABaseAPI {
 
 	@SuppressWarnings("unchecked")
 	@OpenApi(path = ROUTE+"transact",
-			versions="peer-v1",
 			methods = HttpMethod.POST,
 			operationId = "transact",
 			tags= {"Transactions"},
@@ -973,7 +961,6 @@ public class ChainAPI extends ABaseAPI {
 	}
 
 	@OpenApi(path = ROUTE+"transaction/submit",
-			versions="peer-v1",
 			methods = HttpMethod.POST,
 			operationId = "transactionSubmit",
 			tags= {"Transactions"},
@@ -1055,7 +1042,6 @@ public class ChainAPI extends ABaseAPI {
 	}
 
 	@OpenApi(path = ROUTE+"query",
-		versions="peer-v1",
 		methods = HttpMethod.POST,
 		operationId = "query",
 		tags= {"Transactions"},
@@ -1133,7 +1119,6 @@ public class ChainAPI extends ABaseAPI {
 	}
 	
 	@OpenApi(path = "/identicon/{hex}", 
-			versions="peer-v1",
 			methods = HttpMethod.GET, 
 			tags = { "Utility"},
 			summary = "Get the identicon for a hash / public key", 

--- a/convex-restapi/src/main/java/convex/restapi/api/ConfirmAPI.java
+++ b/convex-restapi/src/main/java/convex/restapi/api/ConfirmAPI.java
@@ -9,7 +9,7 @@ import static j2html.TagCreator.text;
 import convex.restapi.RESTServer;
 import convex.restapi.auth.ConfirmationService;
 import convex.restapi.web.AWebSite;
-import io.javalin.Javalin;
+import io.javalin.config.RoutesConfig;
 import io.javalin.http.Context;
 
 /**
@@ -31,9 +31,9 @@ public class ConfirmAPI extends AWebSite {
 	}
 
 	@Override
-	public void addRoutes(Javalin app) {
-		app.get("/confirm", this::handleConfirmGet);
-		app.post("/confirm", this::handleConfirmPost);
+	public void addRoutes(RoutesConfig routes) {
+		routes.get("/confirm", this::handleConfirmGet);
+		routes.post("/confirm", this::handleConfirmPost);
 	}
 
 	/**

--- a/convex-restapi/src/main/java/convex/restapi/api/DIDAPI.java
+++ b/convex-restapi/src/main/java/convex/restapi/api/DIDAPI.java
@@ -6,7 +6,7 @@ import convex.core.data.AccountKey;
 import convex.core.data.Strings;
 import convex.core.util.JSON;
 import convex.restapi.RESTServer;
-import io.javalin.Javalin;
+import io.javalin.config.RoutesConfig;
 import io.javalin.http.Context;
 import io.javalin.http.NotFoundResponse;
 
@@ -33,10 +33,10 @@ public class DIDAPI extends ABaseAPI {
 	}
 
 	@Override
-	public void addRoutes(Javalin app) {
-		app.get("/.well-known/did.json", this::handlePeerDID);
-		app.get("/did/{identifier}/did.json", this::handleAccountDID);
-		app.get("/{identifier}/did.json", this::handleAccountDID);
+	public void addRoutes(RoutesConfig routes) {
+		routes.get("/.well-known/did.json", this::handlePeerDID);
+		routes.get("/did/{identifier}/did.json", this::handleAccountDID);
+		routes.get("/{identifier}/did.json", this::handleAccountDID);
 	}
 
 	/**

--- a/convex-restapi/src/main/java/convex/restapi/api/DLAPI.java
+++ b/convex-restapi/src/main/java/convex/restapi/api/DLAPI.java
@@ -15,7 +15,7 @@ import convex.lattice.fs.DLFSProvider;
 import convex.lattice.fs.DLFileSystem;
 import convex.lattice.fs.DLPath;
 import convex.restapi.RESTServer;
-import io.javalin.Javalin;
+import io.javalin.config.RoutesConfig;
 import io.javalin.http.Context;
 import io.javalin.http.InternalServerErrorResponse;
 import io.javalin.http.NotFoundResponse;
@@ -36,10 +36,10 @@ public class DLAPI extends ABaseAPI {
 	}
 
 	@Override
-	public void addRoutes(Javalin app) {
+	public void addRoutes(RoutesConfig routes) {
 		String prefix=ROUTE;
 
-		app.get(prefix+"<path>", this::getFile);
+		routes.get(prefix+"<path>", this::getFile);
 	}
 	
 	public void getFile(Context ctx) {

--- a/convex-restapi/src/main/java/convex/restapi/api/DepAPI.java
+++ b/convex-restapi/src/main/java/convex/restapi/api/DepAPI.java
@@ -1,7 +1,7 @@
 package convex.restapi.api;
 
 import convex.restapi.RESTServer;
-import io.javalin.Javalin;
+import io.javalin.config.RoutesConfig;
 
 /**
  * Class for Data Ecosystem services
@@ -16,7 +16,7 @@ public class DepAPI extends ABaseAPI {
 	}
 
 	@Override
-	public void addRoutes(Javalin app) {
+	public void addRoutes(RoutesConfig routes) {
 		// TODO Auto-generated method stub
 		
 	}

--- a/convex-restapi/src/main/java/convex/restapi/api/X402.java
+++ b/convex-restapi/src/main/java/convex/restapi/api/X402.java
@@ -10,7 +10,7 @@ import convex.core.data.prim.CVMBool;
 import convex.core.lang.RT;
 import convex.core.util.JSON;
 import convex.restapi.RESTServer;
-import io.javalin.Javalin;
+import io.javalin.config.RoutesConfig;
 import io.javalin.http.BadRequestResponse;
 import io.javalin.http.Context;
 
@@ -33,8 +33,8 @@ public class X402 extends ABaseAPI {
 	}
 
 	@Override
-	public void addRoutes(Javalin app) {
-		app.post(ROUTE, this::handleVerify);
+	public void addRoutes(RoutesConfig routes) {
+		routes.post(ROUTE, this::handleVerify);
 	}
 
 	public void respondPaymentRequired(Context ctx, AMap<AString, ACell> baseFields) {

--- a/convex-restapi/src/main/java/convex/restapi/handler/HttpMethodFilter.java
+++ b/convex-restapi/src/main/java/convex/restapi/handler/HttpMethodFilter.java
@@ -23,7 +23,8 @@ import jakarta.servlet.http.HttpServletResponse;
  * which throws for any name containing characters outside A-Z. Without this
  * guard, such requests (e.g. M-SEARCH probes or lowercase method tokens
  * from scanners) produce a 500 response and a logged exception per request
- * on a public endpoint. With it they get a clean 400 Bad Request before
+ * on a public endpoint. With it they get a clean 501 Not Implemented —
+ * the RFC 9110 response for an unrecognised request method — before
  * reaching Javalin. Well-formed but unknown methods (e.g. FOOBAR) pass
  * through to normal routing and 404 if nothing matches.</p>
  */
@@ -46,7 +47,7 @@ public class HttpMethodFilter implements Filter {
 	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
 			throws IOException, ServletException {
 		if (request instanceof HttpServletRequest req && !isValidMethod(req.getMethod())) {
-			((HttpServletResponse) response).setStatus(400);
+			((HttpServletResponse) response).setStatus(501);
 			return;
 		}
 		chain.doFilter(request, response);

--- a/convex-restapi/src/main/java/convex/restapi/handler/HttpMethodFilter.java
+++ b/convex-restapi/src/main/java/convex/restapi/handler/HttpMethodFilter.java
@@ -1,0 +1,70 @@
+package convex.restapi.handler;
+
+import java.io.IOException;
+import java.util.EnumSet;
+
+import org.eclipse.jetty.ee10.servlet.FilterHolder;
+
+import io.javalin.config.JavalinConfig;
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * Servlet filter rejecting requests whose HTTP method token cannot be
+ * represented by Javalin.
+ *
+ * <p>Javalin resolves request methods via {@code HandlerType.findOrCreate},
+ * which throws for any name containing characters outside A-Z. Without this
+ * guard, such requests (e.g. M-SEARCH probes or lowercase method tokens
+ * from scanners) produce a 500 response and a logged exception per request
+ * on a public endpoint. With it they get a clean 400 Bad Request before
+ * reaching Javalin. Well-formed but unknown methods (e.g. FOOBAR) pass
+ * through to normal routing and 404 if nothing matches.</p>
+ */
+public class HttpMethodFilter implements Filter {
+
+	private static final int MAX_METHOD_LENGTH = 32;
+
+	/**
+	 * Installs this filter on a Javalin server configuration.
+	 *
+	 * @param config Javalin configuration being built
+	 */
+	public static void install(JavalinConfig config) {
+		config.jetty.modifyServletContextHandler(handler ->
+			handler.addFilter(new FilterHolder(new HttpMethodFilter()), "/*",
+					EnumSet.of(DispatcherType.REQUEST)));
+	}
+
+	@Override
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+			throws IOException, ServletException {
+		if (request instanceof HttpServletRequest req && !isValidMethod(req.getMethod())) {
+			((HttpServletResponse) response).setStatus(400);
+			return;
+		}
+		chain.doFilter(request, response);
+	}
+
+	/**
+	 * Checks whether a method token is one Javalin can route (uppercase A-Z only).
+	 *
+	 * @param method HTTP method token from the request line
+	 * @return true if Javalin can represent this method
+	 */
+	public static boolean isValidMethod(String method) {
+		int n = (method == null) ? 0 : method.length();
+		if ((n == 0) || (n > MAX_METHOD_LENGTH)) return false;
+		for (int i = 0; i < n; i++) {
+			char c = method.charAt(i);
+			if ((c < 'A') || (c > 'Z')) return false;
+		}
+		return true;
+	}
+}

--- a/convex-restapi/src/main/java/convex/restapi/mcp/McpAPI.java
+++ b/convex-restapi/src/main/java/convex/restapi/mcp/McpAPI.java
@@ -55,7 +55,7 @@ import convex.restapi.api.ABaseAPI;
 import convex.restapi.api.ChainAPI;
 import convex.restapi.auth.AuthMiddleware;
 import jakarta.servlet.http.HttpServletResponse;
-import io.javalin.Javalin;
+import io.javalin.config.RoutesConfig;
 import io.javalin.http.Context;
 
 /**
@@ -179,11 +179,11 @@ public class McpAPI extends ABaseAPI {
 	}
 
 	@Override
-	public void addRoutes(Javalin app) {
+	public void addRoutes(RoutesConfig routes) {
 		// McpServer handles POST /mcp and GET /.well-known/mcp
 		// We add only the SSE session routes (Convex-specific watch support)
-		app.get("/mcp", this::handleMcpGet);
-		app.delete("/mcp", this::handleMcpDelete);
+		routes.get("/mcp", this::handleMcpGet);
+		routes.delete("/mcp", this::handleMcpDelete);
 	}
 
 	/**

--- a/convex-restapi/src/main/java/convex/restapi/mcp/McpServer.java
+++ b/convex-restapi/src/main/java/convex/restapi/mcp/McpServer.java
@@ -24,7 +24,7 @@ import convex.core.json.JSONReader;
 import convex.core.lang.RT;
 import convex.core.util.JSON;
 import convex.core.util.Utils;
-import io.javalin.Javalin;
+import io.javalin.config.RoutesConfig;
 import io.javalin.http.Context;
 
 /**
@@ -37,7 +37,7 @@ import io.javalin.http.Context;
  *
  * <p>Does not depend on any Convex peer infrastructure. SSE session handling
  * and transport-specific extensions (e.g. state watches) are left to the caller
- * — typically by registering additional routes on the same Javalin app.</p>
+ * — typically by registering additional routes on the same routes configuration.</p>
  *
  * @see <a href="https://www.jsonrpc.org/specification">JSON-RPC 2.0</a>
  * @see <a href="https://modelcontextprotocol.io/specification/2025-11-25">MCP Specification</a>
@@ -151,14 +151,14 @@ public class McpServer {
 	// ==================== Route Registration ====================
 
 	/**
-	 * Registers MCP routes on the given Javalin app.
+	 * Registers MCP routes on the given routes configuration.
 	 * Registers POST and .well-known only. SSE (GET/DELETE) should be added
 	 * by the caller if needed.
 	 */
-	public void addRoutes(Javalin app) {
-		app.before(routePath, this::validateOrigin);
-		app.post(routePath, this::handlePost);
-		app.get("/.well-known/mcp", this::handleWellKnown);
+	public void addRoutes(RoutesConfig routes) {
+		routes.before(routePath, this::validateOrigin);
+		routes.post(routePath, this::handlePost);
+		routes.get("/.well-known/mcp", this::handleWellKnown);
 	}
 
 	// ==================== POST /mcp — JSON-RPC dispatch ====================

--- a/convex-restapi/src/main/java/convex/restapi/web/AuthPage.java
+++ b/convex-restapi/src/main/java/convex/restapi/web/AuthPage.java
@@ -18,7 +18,7 @@ import convex.restapi.RESTServer;
 import convex.restapi.auth.OAuthService;
 import convex.restapi.auth.OAuthService.PendingAuth;
 import convex.restapi.auth.OAuthService.Provider;
-import io.javalin.Javalin;
+import io.javalin.config.RoutesConfig;
 import io.javalin.http.Context;
 import j2html.tags.DomContent;
 
@@ -39,9 +39,9 @@ public class AuthPage extends AWebSite {
 	}
 
 	@Override
-	public void addRoutes(Javalin app) {
-		app.get("/auth", this::showLoginPage);
-		app.get("/auth/callback", this::handleCallback);
+	public void addRoutes(RoutesConfig routes) {
+		routes.get("/auth", this::showLoginPage);
+		routes.get("/auth/callback", this::handleCallback);
 	}
 
 	/**

--- a/convex-restapi/src/main/java/convex/restapi/web/ExplorerAPI.java
+++ b/convex-restapi/src/main/java/convex/restapi/web/ExplorerAPI.java
@@ -71,7 +71,7 @@ import convex.peer.Server;
 import convex.restapi.RESTServer;
 import convex.restapi.api.ABaseAPI;
 import convex.restapi.mcp.McpAPI;
-import io.javalin.Javalin;
+import io.javalin.config.RoutesConfig;
 import io.javalin.http.BadRequestResponse;
 import io.javalin.http.Context;
 import io.javalin.http.NotFoundResponse;
@@ -100,23 +100,23 @@ public class ExplorerAPI extends AWebSite {
 	
 
 	@Override
-	public void addRoutes(Javalin app) {
+	public void addRoutes(RoutesConfig routes) {
 		String prefix = ROUTE;
-		app.get(prefix, this::showExplorer);
-		app.get(prefix+"blocks", this::showBlocks);
-		app.get(prefix+"blocks/{blockNum}", this::showBlock);
-		app.get(prefix+"blocks/{blockNum}/txs/{txNum}", this::showTransaction);
-		app.get(prefix+"states", this::showStates);
-		app.get(prefix+"states/{position}", this::showStatePage);
-		app.get(prefix+"accounts", this::showAccounts);
-		app.get(prefix+"accounts/{accountNum}", this::showAccount);
-		app.get(prefix+"peers", this::showPeers);
-		app.get(prefix+"peers/{peerKey}", this::showPeerDetail);
-		app.get(prefix+"connections", this::showConnections);
-		app.get(prefix+"mcp", this::showMcp);
-		app.get(prefix+"mcp/tools/{toolName}", this::showMcpTool);
-		app.get(prefix+"repl", this::showRepl);
-		app.post(prefix+"search", this::handleSearch);
+		routes.get(prefix, this::showExplorer);
+		routes.get(prefix+"blocks", this::showBlocks);
+		routes.get(prefix+"blocks/{blockNum}", this::showBlock);
+		routes.get(prefix+"blocks/{blockNum}/txs/{txNum}", this::showTransaction);
+		routes.get(prefix+"states", this::showStates);
+		routes.get(prefix+"states/{position}", this::showStatePage);
+		routes.get(prefix+"accounts", this::showAccounts);
+		routes.get(prefix+"accounts/{accountNum}", this::showAccount);
+		routes.get(prefix+"peers", this::showPeers);
+		routes.get(prefix+"peers/{peerKey}", this::showPeerDetail);
+		routes.get(prefix+"connections", this::showConnections);
+		routes.get(prefix+"mcp", this::showMcp);
+		routes.get(prefix+"mcp/tools/{toolName}", this::showMcpTool);
+		routes.get(prefix+"repl", this::showRepl);
+		routes.post(prefix+"search", this::handleSearch);
 	}
 	
 

--- a/convex-restapi/src/main/java/convex/restapi/web/PeerAdminAPI.java
+++ b/convex-restapi/src/main/java/convex/restapi/web/PeerAdminAPI.java
@@ -10,7 +10,7 @@ import convex.peer.Server;
 import convex.restapi.RESTServer;
 import convex.restapi.api.ABaseAPI;
 import convex.restapi.model.CreateAccountResponse;
-import io.javalin.Javalin;
+import io.javalin.config.RoutesConfig;
 import io.javalin.http.Context;
 import io.javalin.openapi.HttpMethod;
 import io.javalin.openapi.OpenApi;
@@ -31,10 +31,10 @@ public class PeerAdminAPI extends ABaseAPI {
 	private static final String ROUTE = "/api/v1/";
 
 	@Override
-	public void addRoutes(Javalin app) {
+	public void addRoutes(RoutesConfig routes) {
 		String prefix = ROUTE;
 
-		app.post(prefix + "peer/shutdown", this::shutDown);
+		routes.post(prefix + "peer/shutdown", this::shutDown);
 	
 	}
 

--- a/convex-restapi/src/main/java/convex/restapi/web/PeerAdminAPI.java
+++ b/convex-restapi/src/main/java/convex/restapi/web/PeerAdminAPI.java
@@ -39,7 +39,6 @@ public class PeerAdminAPI extends ABaseAPI {
 	}
 
 	@OpenApi(path = ROUTE + "peer/shutdown", 
-			versions="peer-v1",
 			methods = HttpMethod.POST, 
 			operationId = "shutdownPeer", 
 			tags = { "Admin"},

--- a/convex-restapi/src/main/java/convex/restapi/web/WebApp.java
+++ b/convex-restapi/src/main/java/convex/restapi/web/WebApp.java
@@ -16,7 +16,7 @@ import convex.core.cvm.State;
 import convex.restapi.RESTServer;
 import convex.restapi.api.ABaseAPI;
 import convex.restapi.mcp.McpAPI;
-import io.javalin.Javalin;
+import io.javalin.config.RoutesConfig;
 import io.javalin.http.Context;
 
 public class WebApp extends AWebSite {
@@ -25,13 +25,13 @@ public class WebApp extends AWebSite {
 		super(restServer);
 	}
 	
-	public void addRoutes(Javalin app) {
-		app.get("/index.html", this::indexPage);
-		app.get("/", this::indexPage);
-		app.get("/404.html", this::missingPage);
-		app.get("/llms.txt",this::llmsTxt);
+	public void addRoutes(RoutesConfig routes) {
+		routes.get("/index.html", this::indexPage);
+		routes.get("/", this::indexPage);
+		routes.get("/404.html", this::missingPage);
+		routes.get("/llms.txt",this::llmsTxt);
 		
-		app.error(404, this::missingPage);
+		routes.error(404, this::missingPage);
 	}
 	
 	private void indexPage(Context ctx) {

--- a/convex-restapi/src/test/java/convex/restapi/test/HttpMethodFilterTest.java
+++ b/convex-restapi/src/test/java/convex/restapi/test/HttpMethodFilterTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
  *
  * <p>Javalin 7 resolves methods via HandlerType.findOrCreate, which throws
  * for any token containing characters outside A-Z. The HttpMethodFilter
- * must convert these to a clean 400 rather than a 500 with a logged
+ * must convert these to a clean 501 rather than a 500 with a logged
  * exception, while well-formed unknown methods fall through to routing.</p>
  */
 public class HttpMethodFilterTest extends ARESTTest {
@@ -33,10 +33,10 @@ public class HttpMethodFilterTest extends ARESTTest {
 	}
 
 	@Test
-	public void testMalformedMethodsReturn400() throws Exception {
-		assertEquals(400, statusOf("M-SEARCH", HOST_PATH + "/"));
-		assertEquals(400, statusOf("VERSION-CONTROL", API_PATH + "/status"));
-		assertEquals(400, statusOf("propfind", HOST_PATH + "/"));
+	public void testMalformedMethodsReturn501() throws Exception {
+		assertEquals(501, statusOf("M-SEARCH", HOST_PATH + "/"));
+		assertEquals(501, statusOf("VERSION-CONTROL", API_PATH + "/status"));
+		assertEquals(501, statusOf("propfind", HOST_PATH + "/"));
 	}
 
 	@Test

--- a/convex-restapi/src/test/java/convex/restapi/test/HttpMethodFilterTest.java
+++ b/convex-restapi/src/test/java/convex/restapi/test/HttpMethodFilterTest.java
@@ -1,0 +1,62 @@
+package convex.restapi.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for rejection of malformed HTTP method tokens.
+ *
+ * <p>Javalin 7 resolves methods via HandlerType.findOrCreate, which throws
+ * for any token containing characters outside A-Z. The HttpMethodFilter
+ * must convert these to a clean 400 rather than a 500 with a logged
+ * exception, while well-formed unknown methods fall through to routing.</p>
+ */
+public class HttpMethodFilterTest extends ARESTTest {
+
+	private static final HttpClient client = HttpClient.newHttpClient();
+
+	private static int statusOf(String method, String url) throws Exception {
+		HttpRequest req = HttpRequest.newBuilder()
+				.uri(URI.create(url))
+				.method(method, HttpRequest.BodyPublishers.noBody())
+				.build();
+		HttpResponse<String> resp = client.send(req, HttpResponse.BodyHandlers.ofString());
+		return resp.statusCode();
+	}
+
+	@Test
+	public void testMalformedMethodsReturn400() throws Exception {
+		assertEquals(400, statusOf("M-SEARCH", HOST_PATH + "/"));
+		assertEquals(400, statusOf("VERSION-CONTROL", API_PATH + "/status"));
+		assertEquals(400, statusOf("propfind", HOST_PATH + "/"));
+	}
+
+	@Test
+	public void testUnknownMethodOnMissingURLReturns404() throws Exception {
+		assertEquals(404, statusOf("FOOBAR", HOST_PATH + "/no-such-url"));
+	}
+
+	@Test
+	public void testValidMethodsUnaffected() throws Exception {
+		assertEquals(200, statusOf("GET", API_PATH + "/status"));
+	}
+
+	@Test
+	public void testMethodValidation() {
+		assertTrue(convex.restapi.handler.HttpMethodFilter.isValidMethod("GET"));
+		assertTrue(convex.restapi.handler.HttpMethodFilter.isValidMethod("PROPFIND"));
+		assertFalse(convex.restapi.handler.HttpMethodFilter.isValidMethod("M-SEARCH"));
+		assertFalse(convex.restapi.handler.HttpMethodFilter.isValidMethod("get"));
+		assertFalse(convex.restapi.handler.HttpMethodFilter.isValidMethod(""));
+		assertFalse(convex.restapi.handler.HttpMethodFilter.isValidMethod(null));
+		assertFalse(convex.restapi.handler.HttpMethodFilter.isValidMethod("A".repeat(33)));
+	}
+}


### PR DESCRIPTION
## Summary

Upgrades convex-restapi and convex-dlfs from Javalin 6.7.0 to 7.2.2 (latest), unblocking the Javalin 7 migration downstream in covia (covia-ai/covia#125).

- **Route registration**: Javalin 7 removed instance route methods (`app.get/post/...`); all `addRoutes` methods now take `io.javalin.config.RoutesConfig` and registration happens inside the `Javalin.create` config block
- **WebDAV custom methods**: PROPFIND/MKCOL/MOVE/COPY/PROPPATCH/LOCK/UNLOCK now use Javalin 7's native `HandlerType.findOrCreate` registration instead of `before()`-hook dispatch on the raw request method
- **Jetty**: connector setup (1 acceptor + 1 selector, virtual-thread request handling) moves to `config.jetty.addConnector`; `app.jettyServer()` no longer exists
- **OpenAPI plugins**: bumped to matching 7.2.2; definition callback ported to `OpenApiSchemaBuilder`
- **Fix**: dropped the unused `versions="peer-v1"` tag from all `@OpenApi` annotations — bare `/openapi` now serves the full spec instead of an empty default document
- **Tidy-up**: removed dead `useSSL` parameter, redundant cast, stdout schema dump

## Breaking API change

`McpServer.addRoutes` and `DLFSWebDAV.addRoutes` signatures change from `Javalin` to `RoutesConfig`. Downstream consumers (covia) must port when adopting a release containing this change — sequencing tracked in covia-ai/covia#125.

## Testing

- Full multi-module build green; convex-restapi 320/320 and convex-dlfs 67/67 tests pass, including Sardine WebDAV client integration tests covering the custom-method port
- Live smoke test: `/openapi`, Swagger UI, ReDoc path, `/.well-known/mcp`, static files, explorer, CORS preflight, `/api/v1/status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)