### PR TITLE
Structural Index merge + DLFS tombstone split

### DIFF
--- a/convex-core/src/main/java/convex/core/data/AMap.java
+++ b/convex-core/src/main/java/convex/core/data/AMap.java
@@ -391,17 +391,20 @@ public abstract class AMap<K extends ACell, V extends ACell> extends ADataStruct
 	/**
 	 * Merge this map with another map, using the given function for each key that
 	 * is present in either map and has a different value
-	 * 
+	 *
 	 * The function is passed null for missing values in either map, and must return
 	 * type V.
-	 * 
+	 *
 	 * If the function returns null, the entry is removed.
-	 * 
-	 * Returns the same map if no changes occurred.
-	 * 
+	 *
+	 * <p>Identity contract: implementations MUST return {@code this} (the exact same
+	 * object, with no allocation) whenever the merged result is equal to {@code this}.
+	 * In particular a no-op merge returns the receiver by reference identity. Callers
+	 * may rely on a {@code result == this} reference check to detect "no change".</p>
+	 *
 	 * @param b    Other map to merge with
 	 * @param func Merge function, returning a new value for each key
-	 * @return A merged map, or this map if no changes occurred
+	 * @return A merged map, or this map (by reference identity) if no changes occurred
 	 */
 	public abstract AMap<K, V> mergeDifferences(AMap<K, V> b, MergeFunction<V> func);
 	

--- a/convex-core/src/main/java/convex/core/data/Index.java
+++ b/convex-core/src/main/java/convex/core/data/Index.java
@@ -838,7 +838,13 @@ public final class Index<K extends ABlobLike<?>, V extends ACell> extends AIndex
 	 * For every key present in either index, applies {@code func} as for
 	 * {@link AMap#mergeDifferences(AMap, MergeFunction)}: a key present on only one side is passed
 	 * with a {@code null} counterpart; a key present in both with equal values is kept unchanged
-	 * without calling {@code func}. Returns {@code this} by reference if the merge is a no-op.
+	 * without calling {@code func}.
+	 *
+	 * <p>Identity contract (see {@link AMap#mergeDifferences}): returns {@code this} (the exact
+	 * same object, no allocation) whenever the merged result equals {@code this}. The result is
+	 * built bottom-up so that any unchanged sub-trie — and hence the whole node — is returned by
+	 * reference identity, not rebuilt. This is verified by the {@code assertSame} cases in
+	 * {@code IndexMergeTest}.</p>
 	 *
 	 * <p>This is a structural radix merge: identical (or value-equal, detected via {@code Ref}
 	 * equality) sub-tries are skipped in O(1) and shared, so the cost and allocation are
@@ -846,7 +852,7 @@ public final class Index<K extends ABlobLike<?>, V extends ACell> extends AIndex
 	 *
 	 * @param b Other index to merge with
 	 * @param func Merge function for Index values
-	 * @return Updated Index (possibly this);
+	 * @return Merged Index, or {@code this} by reference identity if the result is unchanged
 	 */
 	public Index<K, V> mergeDifferences(Index<K, V> b, MergeFunction<V> func) {
 		return mergeNode(this, b, func);

--- a/convex-core/src/main/java/convex/core/data/Index.java
+++ b/convex-core/src/main/java/convex/core/data/Index.java
@@ -833,55 +833,230 @@ public final class Index<K extends ABlobLike<?>, V extends ACell> extends AIndex
 	}
 	
 	/**
-	 * Merge two indexes with a merge function
+	 * Merge two indexes with a merge function.
+	 *
+	 * For every key present in either index, applies {@code func} as for
+	 * {@link AMap#mergeDifferences(AMap, MergeFunction)}: a key present on only one side is passed
+	 * with a {@code null} counterpart; a key present in both with equal values is kept unchanged
+	 * without calling {@code func}. Returns {@code this} by reference if the merge is a no-op.
+	 *
+	 * <p>This is a structural radix merge: identical (or value-equal, detected via {@code Ref}
+	 * equality) sub-tries are skipped in O(1) and shared, so the cost and allocation are
+	 * proportional to the divergence between the two indexes, not their total size.</p>
+	 *
 	 * @param b Other index to merge with
 	 * @param func Merge function for Index values
 	 * @return Updated Index (possibly this);
 	 */
 	public Index<K, V> mergeDifferences(Index<K, V> b, MergeFunction<V> func) {
-		// TODO: make this more efficient
-		if (this.equals(b)) return this;
-		Index<K, V> result=this;
-		long na=this.count;
-		long nb=b.count;
-		
-		// Scan keys in other Index for keys not in this
-		for (long i=0; i<nb; i++) {
-			MapEntry<K,V> me=b.entryAt(i);
-			K k=me.getKey();
-			V v=me.getValue();
-			MapEntry<K,V> mea=this.getEntry(k);
-			if (mea!=null) continue; // skip, will merge in second loop
-			if (!Utils.equals(null,v)) {
-				V nv=func.merge(k,null,v);
-				if (nv==null) {
-					// key already doewn't exist in this
-				} else {
-					// Add new entry
-					result=result.assoc(k, nv);
-				}
+		return mergeNode(this, b, func);
+	}
+
+	/**
+	 * Gets the child Ref for a specific digit, or null if not found.
+	 */
+	private Ref<Index<K, V>> getChildRef(int digit) {
+		int i = Bits.indexForDigit(digit, mask);
+		if (i < 0) return null;
+		return children[i];
+	}
+
+	/**
+	 * Structural recursive merge of two Index nodes. See {@link #mergeDifferences(Index, MergeFunction)}.
+	 */
+	static <K extends ABlobLike<?>, V extends ACell> Index<K, V> mergeNode(Index<K, V> a, Index<K, V> b, MergeFunction<V> func) {
+		if (a == b) return a;                                // shared structure: O(1), no alloc, no hashing
+		if (a.count == 0) return applySide(b, func, false);  // a empty: all of b is right-side
+		if (b.count == 0) return applySide(a, func, true);   // b empty: all of a is left-side
+
+		long da = a.depth, db = b.depth;
+		long pmin = Math.min(da, db);
+		if (pmin > 0) {
+			ABlob pa = a.getPrefix(), pb = b.getPrefix();
+			long m = pa.hexMatch(pb, 0, pmin);
+			if (m < pmin) {
+				// prefixes diverge at digit m: disjoint keyspaces
+				return branchDisjoint(m, pa.getHexDigit(m), a, pb.getHexDigit(m), b, func);
 			}
 		}
-		
-		// Scan keys in this. May remove stuff
-		for (long i=0; i<na; i++) {
-			MapEntry<K,V> me=this.entryAt(i);
-			K k=me.getKey();
-			V v=me.getValue();
-			MapEntry<K,V> meb=b.getEntry(k);
-			V ov=(meb==null)?null:meb.getValue(); // value at same key in other index
-			if (!Utils.equals(v,ov)) {
-				V nv=func.merge(k,v,ov);
-				if (nv==null) {
-					// remove value
-					result=result.dissoc(k);
-				} else if (!Utils.equals(v, nv)){
-					// update value if any change
-					result=result.assoc(k, nv);
-				}
+		// common prefix matches down to the shallower depth: aligned or nested
+		if (da == db) return mergeAligned(a, b, func);
+		return (da < db) ? mergeNested(a, b, func, true)
+		                 : mergeNested(b, a, func, false);
+	}
+
+	/** Merge two nodes that share the same prefix and depth. */
+	private static <K extends ABlobLike<?>, V extends ACell> Index<K, V> mergeAligned(Index<K, V> a, Index<K, V> b, MergeFunction<V> func) {
+		MapEntry<K, V> ne = mergeEntries(a.entry, b.entry, func);
+		Index<K, V>[] kids = null; // built lazily on first child change
+		int um = (a.mask | b.mask) & 0xFFFF;
+		for (int d = 0; d < 16; d++) {
+			if (((um >> d) & 1) == 0) continue;
+			Ref<Index<K, V>> aref = a.getChildRef(d);
+			Ref<Index<K, V>> bref = b.getChildRef(d);
+			Index<K, V> ac = (aref == null) ? null : aref.getValue();
+			Index<K, V> nc;
+			if (aref == null) {
+				nc = applySide(bref.getValue(), func, false);      // b-only child
+			} else if (bref == null) {
+				nc = applySide(ac, func, true);                    // a-only child
+			} else if (aref.equals(bref)) {
+				nc = ac;                                           // identical sub-trie: skip
+			} else {
+				nc = mergeNode(ac, bref.getValue(), func);
+			}
+			if (nc != null && nc.count == 0) nc = null;            // empty child => absent
+			if (nc != ac) {
+				if (kids == null) kids = collectKids(a);
+				kids[d] = nc;
 			}
 		}
-		return result;
+		if (kids == null) {
+			if (ne == a.entry) return a;                          // nothing changed
+			kids = collectKids(a);
+		}
+		return rebuild(a.depth, ne, kids);
+	}
+
+	/**
+	 * Merge a shallower node with a deeper node whose keys nest entirely under one of the
+	 * shallower node's child digits. {@code shallowIsLeft} preserves the (left,right) arg order
+	 * into {@code func} when the deeper node is the left ('own') argument.
+	 */
+	private static <K extends ABlobLike<?>, V extends ACell> Index<K, V> mergeNested(Index<K, V> shallow, Index<K, V> deep, MergeFunction<V> func, boolean shallowIsLeft) {
+		int dig = deep.getPrefix().getHexDigit(shallow.depth);
+		MapEntry<K, V> ne = singleEntry(shallow.entry, func, shallowIsLeft); // shallow entry is single-side
+		Index<K, V>[] kids = null; // built lazily on first change
+		boolean changed = (ne != shallow.entry);
+		int sm = shallow.mask & 0xFFFF;
+		for (int d = 0; d < 16; d++) {
+			if (d == dig) continue;
+			if (((sm >> d) & 1) == 0) continue;
+			Index<K, V> sc = shallow.getChild(d);
+			Index<K, V> nc = applySide(sc, func, shallowIsLeft);
+			if (nc.count == 0) nc = null;
+			if (nc != sc) {
+				if (kids == null) kids = collectKids(shallow);
+				kids[d] = nc;
+				changed = true;
+			}
+		}
+		Index<K, V> scDig = shallow.getChild(dig); // may be null
+		Index<K, V> merged;
+		if (scDig == null) {
+			merged = applySide(deep, func, !shallowIsLeft);
+		} else {
+			merged = shallowIsLeft ? mergeNode(scDig, deep, func) : mergeNode(deep, scDig, func);
+		}
+		if (merged != null && merged.count == 0) merged = null;
+		if (merged != scDig) {
+			if (kids == null) kids = collectKids(shallow);
+			kids[dig] = merged;
+			changed = true;
+		}
+		if (!changed) return shallow; // no-op: deep added nothing, result equals shallow (no allocation)
+		if (kids == null) kids = collectKids(shallow);
+		return rebuild(shallow.depth, ne, kids);
+	}
+
+	/** Build a branch node at depth {@code m} for two disjoint sub-tries (digA != digB). */
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	private static <K extends ABlobLike<?>, V extends ACell> Index<K, V> branchDisjoint(long m, int digA, Index<K, V> a, int digB, Index<K, V> b, MergeFunction<V> func) {
+		Index<K, V> A = applySide(a, func, true);
+		Index<K, V> B = applySide(b, func, false);
+		if (A.count == 0) return B; // if both empty, B is the empty singleton
+		if (B.count == 0) return A;
+		int mask = (1 << digA) | (1 << digB);
+		Ref[] refs = (digA < digB) ? new Ref[] { A.getRef(), B.getRef() }
+		                           : new Ref[] { B.getRef(), A.getRef() };
+		return new Index<K, V>(m, null, refs, (short) mask, A.count + B.count);
+	}
+
+	/** Apply {@code func} to every entry of a node as a single side (other side null). Returns the same node if unchanged. */
+	private static <K extends ABlobLike<?>, V extends ACell> Index<K, V> applySide(Index<K, V> node, MergeFunction<V> func, boolean left) {
+		if (node.count == 0) return node;
+		MapEntry<K, V> ne = singleEntry(node.entry, func, left);
+		Index<K, V>[] kids = null;
+		int m = node.mask & 0xFFFF;
+		for (int d = 0; d < 16; d++) {
+			if (((m >> d) & 1) == 0) continue;
+			Index<K, V> c = node.getChild(d);
+			Index<K, V> nc = applySide(c, func, left);
+			if (nc.count == 0) nc = null;
+			if (nc != c) {
+				if (kids == null) kids = collectKids(node);
+				kids[d] = nc;
+			}
+		}
+		if (kids == null) {
+			if (ne == node.entry) return node;
+			kids = collectKids(node);
+		}
+		return rebuild(node.depth, ne, kids);
+	}
+
+	/** Snapshot a node's children into a digit-indexed array of size 16 (absent digits are null). */
+	@SuppressWarnings("unchecked")
+	private static <K extends ABlobLike<?>, V extends ACell> Index<K, V>[] collectKids(Index<K, V> node) {
+		Index<K, V>[] kids = (Index<K, V>[]) new Index[16];
+		int m = node.mask & 0xFFFF;
+		for (int d = 0; d < 16; d++) {
+			if (((m >> d) & 1) != 0) kids[d] = node.getChild(d);
+		}
+		return kids;
+	}
+
+	/**
+	 * Construct a canonical Index node from a depth, optional entry and a digit-indexed child array.
+	 * Handles the canonicalisation invariants (empty, single-entry, entry-less single-child promotion).
+	 */
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	private static <K extends ABlobLike<?>, V extends ACell> Index<K, V> rebuild(long depth, MapEntry<K, V> entry, Index<K, V>[] kids) {
+		int mask = 0, nk = 0, lastDigit = -1;
+		long count = (entry == null) ? 0 : 1;
+		for (int d = 0; d < 16; d++) {
+			Index<K, V> c = kids[d];
+			if (c == null || c.count == 0) continue;
+			mask |= (1 << d);
+			nk++;
+			lastDigit = d;
+			count += c.count;
+		}
+		if (nk == 0) {
+			if (entry == null) return (Index<K, V>) EMPTY;
+			return new Index<K, V>(depth, entry, EMPTY_CHILDREN, (short) 0, 1);
+		}
+		if (entry == null && nk == 1) return kids[lastDigit]; // promote single child (depth > this depth)
+		Ref[] refs = new Ref[nk];
+		int i = 0;
+		for (int d = 0; d < 16; d++) {
+			Index<K, V> c = kids[d];
+			if (c == null || c.count == 0) continue;
+			refs[i++] = c.getRef();
+		}
+		return new Index<K, V>(depth, entry, refs, (short) mask, count);
+	}
+
+	/** Merge two entries at the same key (either may be null). Returns the surviving entry, or null if removed. */
+	private static <K extends ABlobLike<?>, V extends ACell> MapEntry<K, V> mergeEntries(MapEntry<K, V> ea, MapEntry<K, V> eb, MergeFunction<V> func) {
+		if (eb == null) return singleEntry(ea, func, true);
+		if (ea == null) return singleEntry(eb, func, false);
+		V va = ea.getValue(), vb = eb.getValue();
+		if (Utils.equals(va, vb)) return ea;                  // equal values: keep a's, no func call
+		V nv = func.merge(ea.getKey(), va, vb);
+		if (nv == null) return null;
+		if (Utils.equals(va, nv)) return ea;
+		return ea.withValue(nv);
+	}
+
+	/** Apply {@code func} to a single-side entry (other side null). Returns the entry, or null if removed. */
+	private static <K extends ABlobLike<?>, V extends ACell> MapEntry<K, V> singleEntry(MapEntry<K, V> e, MergeFunction<V> func, boolean left) {
+		if (e == null) return null;
+		V v = e.getValue();
+		V nv = left ? func.merge(e.getKey(), v, null) : func.merge(e.getKey(), null, v);
+		if (nv == null) return null;
+		if (Utils.equals(v, nv)) return e;
+		return e.withValue(nv);
 	}
 
 	@Override

--- a/convex-core/src/main/java/convex/lattice/fs/DLFSLattice.java
+++ b/convex-core/src/main/java/convex/lattice/fs/DLFSLattice.java
@@ -3,6 +3,7 @@ package convex.lattice.fs;
 import convex.core.data.ACell;
 import convex.core.data.AString;
 import convex.core.data.AVector;
+import convex.core.data.Index;
 import convex.core.data.prim.AInteger;
 import convex.core.data.prim.CVMLong;
 import convex.core.util.Utils;
@@ -117,7 +118,15 @@ public class DLFSLattice extends ALattice<AVector<ACell>> {
 		if (!(utime instanceof CVMLong)) {
 			return false;
 		}
-		
+
+		// A 5th element (tombstone index) must be a non-empty Index.
+		// Canonical invariant: POS_TOMBS is present if and only if it is non-empty.
+		if (value.count() > DLFSNode.POS_TOMBS) {
+			ACell tombs = value.get(DLFSNode.POS_TOMBS);
+			if (!(tombs instanceof Index)) return false;
+			if (((Index<?, ?>) tombs).isEmpty()) return false;
+		}
+
 		// Valid DLFS node structure
 		return true;
 	}

--- a/convex-core/src/main/java/convex/lattice/fs/DLFSNode.java
+++ b/convex-core/src/main/java/convex/lattice/fs/DLFSNode.java
@@ -1,5 +1,7 @@
 package convex.lattice.fs;
 
+import java.util.HashSet;
+
 import convex.core.data.ABlob;
 import convex.core.data.ACell;
 import convex.core.data.AString;
@@ -40,6 +42,20 @@ public class DLFSNode {
 
 	private static final AVector<ACell> EMPTY_DIRECTORY=Vectors.of(EMPTY_CONTENTS,NIL_DATA,EMPTY_METADATA,EMPTY_TIME);
 	private static final AVector<ACell> EMPTY_FILE=Vectors.of(NIL_CONTENTS,EMPTY_DATA,EMPTY_METADATA,EMPTY_TIME);
+
+	/**
+	 * Recursive merge of two directory child nodes (live entries). A name present on only one
+	 * side is kept unchanged; names present on both are merged recursively. No instrumentation —
+	 * a purely-live change can never be a tombstone conflict, so the live merge needs none.
+	 */
+	private static final MergeFunction<AVector<ACell>> CHILD_MERGE = new MergeFunction<AVector<ACell>>() {
+		@Override
+		public AVector<ACell> merge(AVector<ACell> ca, AVector<ACell> cb) {
+			if (cb==null) return ca;
+			if (ca==null) return cb;
+			return DLFSNode.merge(ca,cb);
+		}
+	};
 
 
 	
@@ -267,7 +283,7 @@ public class DLFSNode {
 		Index<AString, AVector<ACell>> contB = getDirectoryEntries(b);
 
 		if ((contA!=null)&&(contB!=null)) {
-			// Two directories: merge live entries and tombstones, then reconcile conflicts
+			// Two directories. Merge live entries; reconcile against tombstones only if any exist.
 			Index<AString, CVMLong> tombA = getTombstones(a);
 			Index<AString, CVMLong> tombB = getTombstones(b);
 
@@ -276,20 +292,19 @@ public class DLFSNode {
 				return timeA.compareTo(timeB)>=0?a:b;
 			}
 
-			final java.util.HashSet<AString> touched = new java.util.HashSet<>();
-			Index<AString, AVector<ACell>> mergedDir = contA.mergeDifferences(contB, new MergeFunction<AVector<ACell>>() {
-				@Override
-				public AVector<ACell> merge(AVector<ACell> ca, AVector<ACell> cb) {
-					if (cb==null) return ca;
-					if (ca==null) return cb;
-					return DLFSNode.merge(ca,cb);
-				}
-				@Override
-				public AVector<ACell> merge(Object key, AVector<ACell> ca, AVector<ACell> cb) {
-					touched.add((AString)key);
-					return merge(ca,cb);
-				}
-			});
+			// Live-entry merge needs no instrumentation: a purely-live change is never a conflict.
+			Index<AString, AVector<ACell>> mergedDir = contA.mergeDifferences(contB, CHILD_MERGE);
+
+			// Common case: no deletions anywhere, so no live-vs-dead conflict is possible.
+			if (tombA.isEmpty() && tombB.isEmpty()) {
+				if ((mergedDir==contA)&&(timeA.longValue()>=timeB.longValue())) return a;
+				return buildDirectory(mergeTime, mergedDir, EMPTY_TOMBS);
+			}
+
+			// Merge tombstones, collecting only the names whose tombstone changed. Every live-vs-dead
+			// conflict is necessarily among these (a name dead on both sides is not live in mergedDir),
+			// so reconciliation is proportional to tombstone churn, not to live-entry churn.
+			final HashSet<AString> tombTouched = new HashSet<>();
 			Index<AString, CVMLong> mergedTomb = tombA.mergeDifferences(tombB, new MergeFunction<CVMLong>() {
 				@Override
 				public CVMLong merge(CVMLong ta, CVMLong tb) {
@@ -299,14 +314,13 @@ public class DLFSNode {
 				}
 				@Override
 				public CVMLong merge(Object key, CVMLong ta, CVMLong tb) {
-					touched.add((AString)key);
+					tombTouched.add((AString)key);
 					return merge(ta,tb);
 				}
 			});
 
-			// Reconcile names that ended up both live and tombstoned (create-vs-delete conflicts).
-			// Only names touched by the merges above can conflict, so this is divergence-proportional.
-			for (AString name : touched) {
+			// Reconcile: a name both live and tombstoned resolves by timestamp.
+			for (AString name : tombTouched) {
 				AVector<ACell> live = mergedDir.get(name);
 				if (live==null) continue;
 				CVMLong death = mergedTomb.get(name);

--- a/convex-core/src/main/java/convex/lattice/fs/DLFSNode.java
+++ b/convex-core/src/main/java/convex/lattice/fs/DLFSNode.java
@@ -18,11 +18,17 @@ import convex.core.util.Utils;
 public class DLFSNode {
 	
 	// node structure contents
+	/** Minimum node length. A directory node may carry an optional 5th element (POS_TOMBS). */
 	public static final long NODE_LENGTH = 4;
-	public static final int POS_DIR = 0; // Directory entries as index of nodes
+	public static final int POS_DIR = 0; // Directory entries as index of live child nodes
 	public static final int POS_DATA = 1; // File data as a Blob
 	public static final int POS_METADATA = 2; // arbitrary node metadata
 	public static final int POS_UTIME = 3;
+	/**
+	 * Optional directory tombstone index: maps deleted child name to deletion timestamp.
+	 * Present (node length 5) if and only if non-empty; absent (node length 4) otherwise.
+	 */
+	public static final int POS_TOMBS = 4;
 
 	static final Index<AString,AVector<ACell>> EMPTY_CONTENTS = Index.none();
 	static final Index<AString,AVector<ACell>> NIL_CONTENTS = null;
@@ -30,11 +36,11 @@ public class DLFSNode {
 	static final Blob EMPTY_DATA = Blob.EMPTY;
 	static final ACell EMPTY_METADATA = null;
 	static final CVMLong EMPTY_TIME = CVMLong.ZERO;
-	
+	static final Index<AString,CVMLong> EMPTY_TOMBS = Index.none();
+
 	private static final AVector<ACell> EMPTY_DIRECTORY=Vectors.of(EMPTY_CONTENTS,NIL_DATA,EMPTY_METADATA,EMPTY_TIME);
 	private static final AVector<ACell> EMPTY_FILE=Vectors.of(NIL_CONTENTS,EMPTY_DATA,EMPTY_METADATA,EMPTY_TIME);
-	private static final AVector<ACell> TOMBSTONE=Vectors.of(NIL_CONTENTS,NIL_DATA,EMPTY_METADATA,EMPTY_TIME);
-	
+
 
 	
 	public static boolean isDirectory(AVector<ACell> node) {
@@ -90,29 +96,88 @@ public class DLFSNode {
 	public static AVector<ACell> updateNode(AVector<ACell> rootNode, DLPath path,AVector<ACell> newNode, CVMLong utime) {
 		int n=path.getNameCount();
 		if (n==0) return newNode;
-		
+
 		if (!isDirectory(rootNode)) return null;
-		
+
 		AString name=path.getCVMName(0);
 		Index<AString, AVector<ACell>> entries = getDirectoryEntries(rootNode);
-		AVector<ACell> childNode=entries.get(name);
-		
-		childNode=updateNode(childNode,path.subpath(1),newNode,utime);
-		if (childNode==null) {
-			if (n==1) {
-				// deleting an entry at this position
-				entries=entries.dissoc(name);		
+		if (n==1) {
+			Index<AString, CVMLong> tombs = getTombstones(rootNode);
+			if (newNode==null) {
+				// Internal removal of a live entry (no tombstone recorded)
+				entries=entries.dissoc(name);
 			} else {
-				// we failed
-				return null;
+				// Create or modify: name becomes live, clearing any tombstone for it
+				entries=entries.assoc(name, newNode);
+				tombs=tombs.dissoc(name);
 			}
-		} else {
-			// we have an updated child
-			entries=entries.assoc(name, childNode);
+			return withDir(rootNode, entries, tombs, utime);
 		}
-		AVector<ACell> result=rootNode;
+
+		AVector<ACell> childNode=entries.get(name);
+		childNode=updateNode(childNode,path.subpath(1),newNode,utime);
+		if (childNode==null) return null; // failed: an ancestor on the path was not a directory
+		entries=entries.assoc(name, childNode);
+		return withDir(rootNode, entries, getTombstones(rootNode), utime);
+	}
+
+	/**
+	 * Delete the node at the given path, recording a tombstone (deleted child name to deletion
+	 * timestamp) in its parent directory. The deleted child becomes absent from the live entries.
+	 *
+	 * @param rootNode Root node of the (sub)filesystem
+	 * @param path Path of the node to delete, relative to rootNode
+	 * @param utime Deletion timestamp
+	 * @return Updated root node, or the original node unchanged if the path was not a live node
+	 */
+	public static AVector<ACell> deleteNode(AVector<ACell> rootNode, DLPath path, CVMLong utime) {
+		int n=path.getNameCount();
+		if (n==0) return rootNode; // cannot tombstone the root itself
+		if (!isDirectory(rootNode)) return rootNode;
+		AString name=path.getCVMName(0);
+		Index<AString, AVector<ACell>> entries = getDirectoryEntries(rootNode);
+		if (n==1) {
+			if (entries.get(name)==null) return rootNode; // not a live child
+			entries=entries.dissoc(name);
+			Index<AString, CVMLong> tombs = getTombstones(rootNode).assoc(name, utime);
+			return withDir(rootNode, entries, tombs, utime);
+		}
+		AVector<ACell> childNode=entries.get(name);
+		if (childNode==null) return rootNode; // path does not exist
+		AVector<ACell> newChild=deleteNode(childNode, path.subpath(1), utime);
+		if (newChild==childNode) return rootNode; // nothing changed
+		entries=entries.assoc(name, newChild);
+		return withDir(rootNode, entries, getTombstones(rootNode), utime);
+	}
+
+	/**
+	 * Gets the tombstone index (deleted child name to deletion timestamp) for a directory node.
+	 * Returns the empty index if the node has no tombstones (length 4) or is null.
+	 * @param node Directory node
+	 * @return Tombstone index, never null
+	 */
+	@SuppressWarnings("unchecked")
+	public static Index<AString, CVMLong> getTombstones(AVector<ACell> node) {
+		if (node==null || node.count()<=POS_TOMBS) return EMPTY_TOMBS;
+		return (Index<AString, CVMLong>) node.get(POS_TOMBS);
+	}
+
+	/**
+	 * Rebuilds a directory node with the given live entries, tombstones and timestamp, maintaining
+	 * the canonical invariant that the POS_TOMBS element is present if and only if it is non-empty.
+	 */
+	static AVector<ACell> withDir(AVector<ACell> node, Index<AString, AVector<ACell>> entries, Index<AString, CVMLong> tombs, CVMLong utime) {
+		AVector<ACell> result=node;
 		result=result.assoc(POS_DIR, entries);
 		result=result.assoc(POS_UTIME, utime);
+		boolean has5 = node.count()>POS_TOMBS;
+		if (tombs==null || tombs.isEmpty()) {
+			if (has5) result=result.slice(0, POS_TOMBS); // drop empty tombstone field (5 -> 4)
+		} else if (has5) {
+			result=result.assoc(POS_TOMBS, tombs);
+		} else {
+			result=result.conj(tombs); // append tombstone field (4 -> 5)
+		}
 		return result;
 	}
 	
@@ -151,44 +216,18 @@ public class DLFSNode {
 	}
 
 	/**
-	 * Returns true iff the node is a DLFS tombstone
-	 * @param node Node to test
-	 * @return True if a tombstone, false if anything else (including null)
-	 */
-	public static boolean isTombstone(AVector<ACell> node) {
-		if (node==null) return false;
-		return (!isDirectory(node)&&!isRegularFile(node));
-	}
-
-	/**
-	 * Returns true iff the directory node has no live (non-tombstone) entries.
+	 * Returns true iff the directory node has no live entries.
 	 *
-	 * <p>The raw entries map preserves tombstones for deleted children so they
-	 * can be merged across replicas (CRDT semantics). From the filesystem's
-	 * point of view those entries are gone, so emptiness must be measured
-	 * over live entries only.</p>
+	 * <p>Deleted children are recorded as tombstones in the separate {@link #POS_TOMBS}
+	 * index rather than in the live entries, so emptiness is simply emptiness of the
+	 * live entries.</p>
 	 *
 	 * @param dirNode Node assumed to be a directory
-	 * @return true if {@code dirNode} is a directory with no live children
-	 *         (or not a directory at all — caller decides whether to treat
-	 *         that as a precondition)
+	 * @return true if {@code dirNode} is a directory with no live children (or not a directory)
 	 */
 	public static boolean isEmpty(AVector<ACell> dirNode) {
 		Index<AString, AVector<ACell>> entries = getDirectoryEntries(dirNode);
-		if (entries == null || entries.isEmpty()) return true;
-		long n = entries.count();
-		for (long i = 0; i < n; i++) {
-			if (!isTombstone(entries.entryAt(i).getValue())) return false;
-		}
-		return true;
-	}
-
-	private static AVector<ACell> lastTombstone=TOMBSTONE;
-	public static AVector<ACell> createTombstone(CVMLong timestamp) {
-		AVector<ACell> last=lastTombstone;
-		last= TOMBSTONE.assoc(POS_UTIME,timestamp);
-		lastTombstone=last;
-		return last;
+		return entries == null || entries.isEmpty();
 	}
 
 	private static AVector<ACell> lastDirectory=EMPTY_DIRECTORY;
@@ -227,39 +266,81 @@ public class DLFSNode {
 		Index<AString, AVector<ACell>> contA = getDirectoryEntries(a);
 		Index<AString, AVector<ACell>> contB = getDirectoryEntries(b);
 
-		// might be equal in all content except timestamp, if so take the most recent value.
-		if (Utils.equals(contA, contB)) {
-			if (Utils.equals(getData(a), getData(b))) {
+		if ((contA!=null)&&(contB!=null)) {
+			// Two directories: merge live entries and tombstones, then reconcile conflicts
+			Index<AString, CVMLong> tombA = getTombstones(a);
+			Index<AString, CVMLong> tombB = getTombstones(b);
+
+			// Fast path: identical content except timestamp, take the most recent value
+			if (Utils.equals(contA, contB) && Utils.equals(tombA, tombB)) {
 				return timeA.compareTo(timeB)>=0?a:b;
 			}
-		}
 
-		if ((contA!=null)&&(contB!=null)) {
-			// we have two directories, so need to merge by entry name
-			Index<AString, AVector<ACell>> mergedEntries=contA.mergeDifferences(contB, new MergeFunction<AVector<ACell>>() {
+			final java.util.HashSet<AString> touched = new java.util.HashSet<>();
+			Index<AString, AVector<ACell>> mergedDir = contA.mergeDifferences(contB, new MergeFunction<AVector<ACell>>() {
 				@Override
 				public AVector<ACell> merge(AVector<ACell> ca, AVector<ACell> cb) {
-					// We know values are different at this point
-
-					// nulls mean other map has a missing value
 					if (cb==null) return ca;
 					if (ca==null) return cb;
-
 					return DLFSNode.merge(ca,cb);
+				}
+				@Override
+				public AVector<ACell> merge(Object key, AVector<ACell> ca, AVector<ACell> cb) {
+					touched.add((AString)key);
+					return merge(ca,cb);
+				}
+			});
+			Index<AString, CVMLong> mergedTomb = tombA.mergeDifferences(tombB, new MergeFunction<CVMLong>() {
+				@Override
+				public CVMLong merge(CVMLong ta, CVMLong tb) {
+					if (ta==null) return tb;
+					if (tb==null) return ta;
+					return ta.longValue()>=tb.longValue()?ta:tb;
+				}
+				@Override
+				public CVMLong merge(Object key, CVMLong ta, CVMLong tb) {
+					touched.add((AString)key);
+					return merge(ta,tb);
 				}
 			});
 
-			// Helps performance a lot if we can return a directly with no changes
-			if ((contA==mergedEntries)&&(timeA.longValue()>=mergeTime.longValue())) return a;
+			// Reconcile names that ended up both live and tombstoned (create-vs-delete conflicts).
+			// Only names touched by the merges above can conflict, so this is divergence-proportional.
+			for (AString name : touched) {
+				AVector<ACell> live = mergedDir.get(name);
+				if (live==null) continue;
+				CVMLong death = mergedTomb.get(name);
+				if (death==null) continue;
+				if (death.longValue() >= getUTime(live).longValue()) {
+					mergedDir = mergedDir.dissoc(name);   // deletion wins (tombstone preferred on tie)
+				} else {
+					mergedTomb = mergedTomb.dissoc(name);  // newer create/modify wins
+				}
+			}
 
-			AVector<ACell> result=createDirectory(mergeTime);
-			result=result.assoc(POS_DIR, mergedEntries);
-			return result;
-		} else {
-			// at least one in not a directory, so select based on more recent timestamp, or choose a if equal
-			AVector<ACell> result= timeA.longValue()>=timeB.longValue()?a:b;
-			return result;
+			// Return a unchanged if it already subsumes b (no allocation)
+			if ((mergedDir==contA)&&(mergedTomb==tombA)&&(timeA.longValue()>=timeB.longValue())) return a;
+			return buildDirectory(mergeTime, mergedDir, mergedTomb);
 		}
+
+		// At least one node is a file: equal content keeps the most recent; otherwise newer wins
+		if (Utils.equals(contA, contB) && Utils.equals(getData(a), getData(b))) {
+			return timeA.compareTo(timeB)>=0?a:b;
+		}
+		return timeA.longValue()>=timeB.longValue()?a:b;
+	}
+
+	/**
+	 * Builds a canonical directory node from merged live entries and tombstones, with the
+	 * POS_TOMBS element present if and only if the tombstone index is non-empty.
+	 */
+	static AVector<ACell> buildDirectory(CVMLong utime, Index<AString, AVector<ACell>> entries, Index<AString, CVMLong> tombs) {
+		AVector<ACell> result=createDirectory(utime);
+		result=result.assoc(POS_DIR, entries);
+		if (tombs!=null && !tombs.isEmpty()) {
+			result=result.conj(tombs);
+		}
+		return result;
 	}
 
 }

--- a/convex-core/src/main/java/convex/lattice/fs/DLFileSystem.java
+++ b/convex-core/src/main/java/convex/lattice/fs/DLFileSystem.java
@@ -189,7 +189,7 @@ public abstract class DLFileSystem extends FileSystem implements Cloneable {
 
 	DLFSFileAttributes getFileAttributes(DLPath path) throws java.nio.file.NoSuchFileException {
 		AVector<ACell> node=getNode(path);
-		if (node==null || DLFSNode.isTombstone(node)) {
+		if (node==null) {
 			throw new java.nio.file.NoSuchFileException(path.toString());
 		}
 		return DLFSFileAttributes.create(node);

--- a/convex-core/src/main/java/convex/lattice/fs/impl/DLDirectoryStream.java
+++ b/convex-core/src/main/java/convex/lattice/fs/impl/DLDirectoryStream.java
@@ -16,28 +16,20 @@ import convex.lattice.fs.DLPath;
 public class DLDirectoryStream implements DirectoryStream<Path> {
 
 	/**
-	 * Iterator that walks the raw entries map, skipping tombstones so callers
-	 * see only live children. Tombstones are CRDT plumbing and shouldn't leak
-	 * into the filesystem view.
+	 * Iterator over the directory's live entries. Deleted children are recorded as
+	 * tombstones in the parent node's separate POS_TOMBS index, not in the live entries,
+	 * so this map already contains exactly the visible children.
 	 */
 	public class DIterator implements Iterator<Path> {
 		long pos=0;
 
-		private void advanceToLive() {
-			while (pos<dirs.count() && DLFSNode.isTombstone(dirs.entryAt(pos).getValue())) {
-				pos++;
-			}
-		}
-
 		@Override
 		public boolean hasNext() {
-			advanceToLive();
 			return pos<dirs.count();
 		}
 
 		@Override
 		public DLPath next() {
-			advanceToLive();
 			if (pos>=dirs.count()) throw new NoSuchElementException();
 			return base.resolve(dirs.entryAt(pos++).getKey());
 		}

--- a/convex-core/src/main/java/convex/lattice/fs/impl/DLFSFileAttributes.java
+++ b/convex-core/src/main/java/convex/lattice/fs/impl/DLFSFileAttributes.java
@@ -58,7 +58,7 @@ public class DLFSFileAttributes implements BasicFileAttributes {
 
 	@Override
 	public boolean isOther() {
-		return DLFSNode.isTombstone(node);
+		return false;
 	}
 
 	@Override

--- a/convex-core/src/main/java/convex/lattice/fs/impl/DLFSLocal.java
+++ b/convex-core/src/main/java/convex/lattice/fs/impl/DLFSLocal.java
@@ -93,9 +93,9 @@ public class DLFSLocal extends DLFileSystem {
 		if (parentNode==null) {
 			throw new NoSuchFileException(parent.toString());
 		}
-		// Replacing a tombstone is fine — the path is logically free.
+		// A live entry blocks creation; a tombstoned name is absent from live entries, so it is free.
 		AVector<ACell> existing = DLFSNode.getDirectoryEntries(parentNode).get(name);
-		if (existing != null && !DLFSNode.isTombstone(existing)) {
+		if (existing != null) {
 			throw new FileAlreadyExistsException(dir.toString());
 		}
 		updateNode(dir,DLFSNode.createDirectory(getTimestamp()));
@@ -115,9 +115,7 @@ public class DLFSLocal extends DLFileSystem {
 		}
 		AVector<ACell> oldNode=DLFSNode.getDirectoryEntries(parentNode).get(name);
 		if (oldNode!=null) {
-			if (!DLFSNode.isTombstone(oldNode)) {
-				throw new FileAlreadyExistsException(name.toString());
-			}
+			throw new FileAlreadyExistsException(name.toString());
 		}
 		AVector<ACell> newNode=DLFSNode.createEmptyFile(getTimestamp());
 		updateNode(path,newNode);
@@ -127,23 +125,22 @@ public class DLFSLocal extends DLFileSystem {
 
 	@Override
 	public synchronized void delete(DLPath path) throws IOException {
-		path=path.toAbsolutePath();
-		if (path.getNameCount()==0) {
+		final DLPath p=path.toAbsolutePath();
+		if (p.getNameCount()==0) {
 			throw new IOException("Can't delete DLFS Root node");
 		}
-		
+
 		// Check file actually exists
-		AVector<ACell> node=getNode(path);
-		if (node==null) throw new NoSuchFileException(path.toString());
-		
-		// Check it is empty, if a directory. Tombstones don't count: the raw
-		// entries map keeps them for CRDT merge, but the filesystem view of
-		// "empty" only cares about live children.
+		AVector<ACell> node=getNode(p);
+		if (node==null) throw new NoSuchFileException(p.toString());
+
+		// A directory can only be deleted if it has no live children
 		if (DLFSNode.isDirectory(node) && !DLFSNode.isEmpty(node)) {
-			throw new DirectoryNotEmptyException(path.toString());
+			throw new DirectoryNotEmptyException(p.toString());
 		}
-		
-		updateNode(path,DLFSNode.createTombstone(getTimestamp()));
+
+		// Drop the live entry and record a tombstone in the parent directory
+		rootCursor.updateAndGet(rootNode->DLFSNode.deleteNode(rootNode,p,getTimestamp()));
 	}
 
 	@Override
@@ -156,7 +153,7 @@ public class DLFSLocal extends DLFileSystem {
 	protected void checkAccess(DLPath path) throws IOException {
 		AVector<ACell> rootNode=rootCursor.get();
 		AVector<ACell> node=DLFSNode.navigate(rootNode,path);
-		if ((node==null)||(DLFSNode.isTombstone(node))) {
+		if (node==null) {
 			throw new NoSuchFileException(path.toString());
 		}
 	}

--- a/convex-core/src/main/java/convex/lattice/fs/impl/DLFileChannel.java
+++ b/convex-core/src/main/java/convex/lattice/fs/impl/DLFileChannel.java
@@ -45,10 +45,7 @@ public class DLFileChannel implements SeekableByteChannel {
 			}
 			if (options.contains(StandardOpenOption.CREATE_NEW)) {
 				if (node!=null) {
-					// can create over a tombstone
-					if(!DLFSNode.isTombstone(node)) {
-						throw new FileAlreadyExistsException(path.toString());
-					}
+					throw new FileAlreadyExistsException(path.toString());
 				}
 			}
 			if (options.contains(StandardOpenOption.APPEND)) {
@@ -59,7 +56,7 @@ public class DLFileChannel implements SeekableByteChannel {
 			}
 		}
 		
-		if ((node==null)||DLFSNode.isTombstone(node)) {
+		if (node==null) {
 			if (readOnly) throw new NoSuchFileException(path.toString());
 			node=fs.createFile(path);
 		} else {

--- a/convex-core/src/test/java/convex/core/data/IndexMergeTest.java
+++ b/convex-core/src/test/java/convex/core/data/IndexMergeTest.java
@@ -1,0 +1,201 @@
+package convex.core.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.junit.jupiter.api.Test;
+
+import convex.core.data.prim.CVMLong;
+import convex.core.exceptions.InvalidDataException;
+import convex.core.util.MergeFunction;
+import convex.core.util.Utils;
+
+/**
+ * Tests for {@link Index#mergeDifferences(Index, MergeFunction)}, the structural radix merge.
+ *
+ * <p>The structural merge must be bit-identical to the original naive double-scan implementation
+ * (reproduced here as the {@link #naive} oracle) for all inputs and merge functions, and must
+ * return its left argument by reference identity when the merge is a no-op (no spurious allocation).</p>
+ */
+public class IndexMergeTest {
+
+	// ---- Merge functions under test ----
+
+	/** Left-biased, identity on single side. */
+	static final MergeFunction<CVMLong> PICK_A = new MergeFunction<>() {
+		public CVMLong merge(CVMLong a, CVMLong b) { return a != null ? a : b; }
+	};
+	/** Right-biased, identity on single side. */
+	static final MergeFunction<CVMLong> PICK_B = new MergeFunction<>() {
+		public CVMLong merge(CVMLong a, CVMLong b) { return b != null ? b : a; }
+	};
+	/** Lattice-style max, identity on single side AND on the winning side. */
+	static final MergeFunction<CVMLong> MAX = new MergeFunction<>() {
+		public CVMLong merge(CVMLong a, CVMLong b) {
+			if (a == null) return b;
+			if (b == null) return a;
+			return a.longValue() >= b.longValue() ? a : b;
+		}
+	};
+	/** Transforms even on a single side (never returns the input ref). */
+	static final MergeFunction<CVMLong> SUM = new MergeFunction<>() {
+		public CVMLong merge(CVMLong a, CVMLong b) {
+			return CVMLong.create((a == null ? 0 : a.longValue()) + (b == null ? 0 : b.longValue()));
+		}
+	};
+	/** Drops (returns null) when the merged value is even — exercises dissoc/empty-child collapse. */
+	static final MergeFunction<CVMLong> DROP_EVEN = new MergeFunction<>() {
+		public CVMLong merge(CVMLong a, CVMLong b) {
+			long x = (a == null) ? (b == null ? 0 : b.longValue())
+					: (b == null ? a.longValue() : Math.max(a.longValue(), b.longValue()));
+			return ((x & 1L) == 0L) ? null : CVMLong.create(x);
+		}
+	};
+
+	static final List<MergeFunction<CVMLong>> FUNCS = List.of(PICK_A, PICK_B, MAX, SUM, DROP_EVEN);
+
+	// ---- Naive reference: the original algorithm we must stay bit-identical to ----
+
+	static Index<ABlob, CVMLong> naive(Index<ABlob, CVMLong> a, Index<ABlob, CVMLong> b, MergeFunction<CVMLong> func) {
+		Index<ABlob, CVMLong> result = a;
+		long nb = b.count();
+		for (long i = 0; i < nb; i++) {
+			MapEntry<ABlob, CVMLong> me = b.entryAt(i);
+			ABlob k = me.getKey();
+			CVMLong v = me.getValue();
+			if (a.getEntry(k) != null) continue; // present in both: handled in second loop
+			CVMLong nv = func.merge(k, null, v);
+			if (nv != null) result = result.assoc(k, nv);
+		}
+		long na = a.count();
+		for (long i = 0; i < na; i++) {
+			MapEntry<ABlob, CVMLong> me = a.entryAt(i);
+			ABlob k = me.getKey();
+			CVMLong v = me.getValue();
+			MapEntry<ABlob, CVMLong> meb = b.getEntry(k);
+			CVMLong ov = (meb == null) ? null : meb.getValue();
+			if (!Utils.equals(v, ov)) {
+				CVMLong nv = func.merge(k, v, ov);
+				if (nv == null) result = result.dissoc(k);
+				else if (!Utils.equals(v, nv)) result = result.assoc(k, nv);
+			}
+		}
+		return result;
+	}
+
+	// ---- Key generation: biased prefixes to exercise aligned / disjoint / nested cases ----
+
+	static ABlob randomKey(Random r) {
+		int len = 1 + r.nextInt(40); // 1..40 bytes (spans < and > MAX_DEPTH = 64 hex digits)
+		byte[] bs = new byte[len];
+		r.nextBytes(bs);
+		// Squeeze the leading bytes into a small alphabet so keys share prefixes (and some nest).
+		bs[0] = (byte) r.nextInt(4);
+		if (len > 1) bs[1] = (byte) r.nextInt(4);
+		return Blob.wrap(bs);
+	}
+
+	@Test
+	public void testFuzzMatchesNaive() {
+		for (int seed = 0; seed < 300; seed++) {
+			Random r = new Random(seed);
+			int np = 1 + r.nextInt(40);
+			List<ABlob> keys = new ArrayList<>();
+			for (int i = 0; i < np; i++) keys.add(randomKey(r));
+
+			Index<ABlob, CVMLong> a = Index.none();
+			Index<ABlob, CVMLong> b = Index.none();
+			for (ABlob k : keys) {
+				int where = r.nextInt(4); // 0:a-only 1:b-only 2:both-equal 3:both-different
+				CVMLong va = CVMLong.create(r.nextInt(100));
+				CVMLong vb = CVMLong.create(r.nextInt(100));
+				switch (where) {
+					case 0 -> a = a.assoc(k, va);
+					case 1 -> b = b.assoc(k, vb);
+					case 2 -> { a = a.assoc(k, va); b = b.assoc(k, va); }
+					default -> { a = a.assoc(k, va); b = b.assoc(k, vb); }
+				}
+			}
+
+			for (MergeFunction<CVMLong> f : FUNCS) {
+				Index<ABlob, CVMLong> got = a.mergeDifferences(b, f);
+				Index<ABlob, CVMLong> exp = naive(a, b, f);
+				String ctx = "seed=" + seed + " func=" + FUNCS.indexOf(f);
+				assertEquals(exp, got, ctx);                       // same content
+				assertEquals(exp.getHash(), got.getHash(), ctx);   // therefore bit-identical encoding
+				try {
+					got.validate();                                // result is canonical
+				} catch (InvalidDataException e) {
+					fail(ctx + " produced non-canonical Index: " + e.getMessage());
+				}
+			}
+		}
+	}
+
+	@Test
+	public void testMergeIsCommutativeForLatticeFunc() {
+		// MAX is a commutative lattice join: merge(a,b) and merge(b,a) must agree.
+		for (int seed = 1000; seed < 1100; seed++) {
+			Random r = new Random(seed);
+			Index<ABlob, CVMLong> a = Index.none();
+			Index<ABlob, CVMLong> b = Index.none();
+			int n = 1 + r.nextInt(40);
+			for (int i = 0; i < n; i++) {
+				a = a.assoc(randomKey(r), CVMLong.create(r.nextInt(50)));
+				b = b.assoc(randomKey(r), CVMLong.create(r.nextInt(50)));
+			}
+			assertEquals(a.mergeDifferences(b, MAX), b.mergeDifferences(a, MAX), "seed=" + seed);
+		}
+	}
+
+	@Test
+	public void testNoOpReturnsIdentity() {
+		Random r = new Random(42);
+		Index<ABlob, CVMLong> a = Index.none();
+		List<ABlob> keys = new ArrayList<>();
+		for (int i = 0; i < 60; i++) {
+			ABlob k = randomKey(r);
+			keys.add(k);
+			a = a.assoc(k, CVMLong.create(r.nextInt(1000)));
+		}
+
+		// Merging with self short-circuits.
+		assertSame(a, a.mergeDifferences(a, PICK_A));
+
+		// Merging with empty, identity-on-single-side func: no allocation, returns the same object.
+		assertSame(a, a.mergeDifferences(Index.none(), MAX));
+		assertSame(a, a.mergeDifferences(Index.none(), PICK_A));
+
+		// Merging with an independently-built subset of itself (equal values), left-biased:
+		// every key is either equal-in-both or a-only, so the result is a with zero allocation.
+		Index<ABlob, CVMLong> subset = Index.none();
+		for (int i = 0; i < keys.size(); i += 2) {
+			ABlob k = keys.get(i);
+			subset = subset.assoc(k, a.get(k));
+		}
+		assertSame(a, a.mergeDifferences(subset, PICK_A));
+		assertSame(a, a.mergeDifferences(subset, MAX));
+	}
+
+	@Test
+	public void testDisjointAndNested() {
+		// Disjoint prefixes (different first digit).
+		Index<ABlob, CVMLong> a = Index.of(Blob.fromHex("10ab"), CVMLong.create(1), Blob.fromHex("12cd"), CVMLong.create(2));
+		Index<ABlob, CVMLong> b = Index.of(Blob.fromHex("20ef"), CVMLong.create(3));
+		Index<ABlob, CVMLong> m = a.mergeDifferences(b, PICK_A);
+		assertEquals(naive(a, b, PICK_A), m);
+		assertEquals(3L, m.count());
+
+		// Nested: b's key extends a's key prefix (one key is a strict prefix of the other).
+		Index<ABlob, CVMLong> c = Index.of(Blob.fromHex("ab"), CVMLong.create(1));
+		Index<ABlob, CVMLong> d = Index.of(Blob.fromHex("abcd"), CVMLong.create(2), Blob.fromHex("abef"), CVMLong.create(3));
+		Index<ABlob, CVMLong> mn = c.mergeDifferences(d, PICK_B);
+		assertEquals(naive(c, d, PICK_B), mn);
+		assertEquals(3L, mn.count());
+	}
+}

--- a/convex-core/src/test/java/convex/core/data/IndexMergeTest.java
+++ b/convex-core/src/test/java/convex/core/data/IndexMergeTest.java
@@ -1,6 +1,7 @@
 package convex.core.data;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -153,33 +154,81 @@ public class IndexMergeTest {
 		}
 	}
 
+	/**
+	 * Functions that preserve a single-side value: {@code func(v, null)} and {@code func(null, v)}
+	 * are equal to {@code v}. Merging with such a function is a no-op when nothing new is added.
+	 * (DROP_EVEN is excluded — it can drop a one-sided value.)
+	 */
+	static final List<MergeFunction<CVMLong>> SINGLE_SIDE_PRESERVING = List.of(PICK_A, PICK_B, MAX, SUM);
+
+	static Index<ABlob, CVMLong> copyOf(Index<ABlob, CVMLong> a) {
+		Index<ABlob, CVMLong> m = Index.none();
+		long n = a.count();
+		for (long i = 0; i < n; i++) {
+			MapEntry<ABlob, CVMLong> e = a.entryAt(i);
+			m = m.assoc(e.getKey(), e.getValue());
+		}
+		return m;
+	}
+
+	static Index<ABlob, CVMLong> subsetOf(Index<ABlob, CVMLong> a, Random r) {
+		Index<ABlob, CVMLong> m = Index.none();
+		long n = a.count();
+		for (long i = 0; i < n; i++) {
+			if (r.nextBoolean()) {
+				MapEntry<ABlob, CVMLong> e = a.entryAt(i);
+				m = m.assoc(e.getKey(), e.getValue());
+			}
+		}
+		return m;
+	}
+
+	/**
+	 * Identity contract: {@code mergeDifferences} MUST return the receiver by reference identity
+	 * whenever the merged result equals the receiver (no allocation on a no-op). Exercised across
+	 * random radix structures so the aligned, nested and empty cases all occur.
+	 */
 	@Test
 	public void testNoOpReturnsIdentity() {
-		Random r = new Random(42);
-		Index<ABlob, CVMLong> a = Index.none();
-		List<ABlob> keys = new ArrayList<>();
-		for (int i = 0; i < 60; i++) {
-			ABlob k = randomKey(r);
-			keys.add(k);
-			a = a.assoc(k, CVMLong.create(r.nextInt(1000)));
+		for (int seed = 2000; seed < 2200; seed++) {
+			Random r = new Random(seed);
+			Index<ABlob, CVMLong> a = Index.none();
+			int n = 1 + r.nextInt(40);
+			for (int i = 0; i < n; i++) a = a.assoc(randomKey(r), CVMLong.create(r.nextInt(1000)));
+			String ctx = "seed=" + seed;
+
+			// 1. Self-merge: no function is invoked, identity for every function
+			for (MergeFunction<CVMLong> f : FUNCS) assertSame(a, a.mergeDifferences(a, f), "self " + ctx);
+
+			// 2. Independently-built equal copy: still no function invoked, identity for every function
+			Index<ABlob, CVMLong> copy = copyOf(a);
+			assertNotSame(a, copy); // genuinely a different object with equal content
+			for (MergeFunction<CVMLong> f : FUNCS) assertSame(a, a.mergeDifferences(copy, f), "copy " + ctx);
+
+			// 3. Empty right operand, single-side-preserving function: identity
+			for (MergeFunction<CVMLong> f : SINGLE_SIDE_PRESERVING)
+				assertSame(a, a.mergeDifferences(Index.none(), f), "empty " + ctx);
+
+			// 4. Independently-built subset (covers aligned + nested no-ops), single-side-preserving: identity
+			Index<ABlob, CVMLong> subset = subsetOf(a, r);
+			for (MergeFunction<CVMLong> f : SINGLE_SIDE_PRESERVING)
+				assertSame(a, a.mergeDifferences(subset, f), "subset " + ctx);
 		}
+	}
 
-		// Merging with self short-circuits.
-		assertSame(a, a.mergeDifferences(a, PICK_A));
-
-		// Merging with empty, identity-on-single-side func: no allocation, returns the same object.
-		assertSame(a, a.mergeDifferences(Index.none(), MAX));
-		assertSame(a, a.mergeDifferences(Index.none(), PICK_A));
-
-		// Merging with an independently-built subset of itself (equal values), left-biased:
-		// every key is either equal-in-both or a-only, so the result is a with zero allocation.
-		Index<ABlob, CVMLong> subset = Index.none();
-		for (int i = 0; i < keys.size(); i += 2) {
-			ABlob k = keys.get(i);
-			subset = subset.assoc(k, a.get(k));
+	/** Directed no-op through the nested (path-compressed) case: a key that is a prefix of others. */
+	@Test
+	public void testNoOpNestedCase() {
+		Index<ABlob, CVMLong> a = Index.of(
+			Blob.fromHex("ab"), CVMLong.create(1),
+			Blob.fromHex("abcd"), CVMLong.create(2),
+			Blob.fromHex("abef"), CVMLong.create(3));
+		// b nests a single deeper key already present in a with the same value
+		Index<ABlob, CVMLong> b = Index.of(Blob.fromHex("abcd"), CVMLong.create(2));
+		assertNotSame(a, b);
+		for (MergeFunction<CVMLong> f : SINGLE_SIDE_PRESERVING) {
+			assertSame(a, a.mergeDifferences(b, f), "func=" + SINGLE_SIDE_PRESERVING.indexOf(f));
 		}
-		assertSame(a, a.mergeDifferences(subset, PICK_A));
-		assertSame(a, a.mergeDifferences(subset, MAX));
 	}
 
 	@Test

--- a/convex-core/src/test/java/convex/lattice/fs/DLFSTest.java
+++ b/convex-core/src/test/java/convex/lattice/fs/DLFSTest.java
@@ -202,10 +202,9 @@ public class DLFSTest {
 
 	@Test
 	public void testDeleteAfterChildrenTombstoned() throws IOException {
-		// Regression: previously a directory whose children had been deleted
-		// could not itself be deleted, because the entries map kept tombstones
-		// and entries.isEmpty() returned false. Now uses DLFSNode.isEmpty
-		// which filters tombstones.
+		// A directory whose children have all been deleted is logically empty:
+		// deletions move children out of the live entries into the parent's
+		// POS_TOMBS index, so the directory itself can then be deleted.
 		DLFileSystem fs = DLFS.createLocal();
 		Path root = fs.getRoot();
 		Path tree = Files.createDirectory(root.resolve("tree"));
@@ -217,12 +216,12 @@ public class DLFSTest {
 		Files.delete(a);
 		Files.delete(b);
 
-		// All children gone — directory is logically empty even though the
-		// entries map still has tombstones. Delete must succeed.
+		// All children gone — the directory's live entries are empty (their
+		// tombstones live in the parent's POS_TOMBS index). Delete must succeed.
 		Files.delete(tree);
 		assertFalse(Files.exists(tree));
 
-		// Iteration view skips tombstones too — root no longer shows tree.
+		// Listing shows only live entries — root no longer shows tree.
 		try (DirectoryStream<Path> ds = Files.newDirectoryStream(root)) {
 			assertFalse(ds.iterator().hasNext());
 		}

--- a/convex-core/src/test/java/convex/lattice/fs/DLFSTombstoneTest.java
+++ b/convex-core/src/test/java/convex/lattice/fs/DLFSTombstoneTest.java
@@ -1,0 +1,136 @@
+package convex.lattice.fs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+import convex.core.data.ACell;
+import convex.core.data.AString;
+import convex.core.data.AVector;
+import convex.core.data.Index;
+import convex.core.data.Strings;
+import convex.core.data.prim.CVMLong;
+import convex.lattice.fs.impl.DLFSLocal;
+
+/**
+ * Tests for the split node structure: live children in POS_DIR, deletions recorded as
+ * tombstones (name to deletion timestamp) in the optional POS_TOMBS index.
+ */
+public class DLFSTombstoneTest {
+
+	/** A directory node carries the POS_TOMBS element if and only if it has tombstones. */
+	@Test
+	public void testCanonicalNodeShape() throws IOException {
+		DLFSLocal fs = DLFS.create();
+		fs.setTimestamp(CVMLong.create(100));
+		DLPath root = fs.getRoot();
+		Path f = Files.createFile(root.resolve("f.txt"));
+
+		// No deletions yet: plain 4-element directory node
+		AVector<ACell> r0 = fs.getNode(root);
+		assertEquals(DLFSNode.NODE_LENGTH, r0.count());
+		assertTrue(DLFSNode.getTombstones(r0).isEmpty());
+
+		// Delete records a tombstone with the deletion timestamp; node grows to 5 elements
+		fs.setTimestamp(CVMLong.create(200));
+		Files.delete(f);
+		AVector<ACell> r1 = fs.getNode(root);
+		assertEquals(5L, r1.count());
+		Index<AString, CVMLong> tombs = DLFSNode.getTombstones(r1);
+		assertEquals(1L, tombs.count());
+		assertEquals(CVMLong.create(200), tombs.get(Strings.create("f.txt")));
+		assertTrue(DLFSNode.isEmpty(r1));        // no live children
+		assertFalse(Files.exists(f));
+
+		// Recreating clears the tombstone, returning the node to canonical 4-element form
+		fs.setTimestamp(CVMLong.create(300));
+		Files.createFile(root.resolve("f.txt"));
+		AVector<ACell> r2 = fs.getNode(root);
+		assertEquals(DLFSNode.NODE_LENGTH, r2.count());
+		assertTrue(DLFSNode.getTombstones(r2).isEmpty());
+		assertTrue(Files.exists(root.resolve("f.txt")));
+	}
+
+	/** A creation newer than a concurrent deletion wins after merge, on both replicas. */
+	@Test
+	public void testNewerCreateBeatsDelete() throws IOException {
+		DLFSLocal a = DLFS.create();
+		DLFSLocal b = DLFS.create();
+
+		// A holds a fresh file created at t=200
+		a.setTimestamp(CVMLong.create(200));
+		Files.write(a.getPath("/x"), new byte[] { 9 });
+
+		// B created then deleted the same name earlier: it holds only a tombstone at t=100
+		b.setTimestamp(CVMLong.create(50));
+		Files.write(b.getPath("/x"), new byte[] { 1 });
+		b.setTimestamp(CVMLong.create(100));
+		Files.delete(b.getPath("/x"));
+
+		a.replicate(b);
+		b.replicate(a);
+
+		// 200 > 100: the file survives on both, and the replicas converge
+		assertTrue(Files.exists(a.getPath("/x")));
+		assertTrue(Files.exists(b.getPath("/x")));
+		assertEquals(a.getRootHash(), b.getRootHash());
+	}
+
+	/** A deletion newer than a concurrent creation wins after merge, on both replicas. */
+	@Test
+	public void testNewerDeleteBeatsCreate() throws IOException {
+		DLFSLocal a = DLFS.create();
+		DLFSLocal b = DLFS.create();
+
+		// A holds a file created at t=100
+		a.setTimestamp(CVMLong.create(100));
+		Files.write(a.getPath("/y"), new byte[] { 9 });
+
+		// B deleted the name at t=200
+		b.setTimestamp(CVMLong.create(50));
+		Files.write(b.getPath("/y"), new byte[] { 1 });
+		b.setTimestamp(CVMLong.create(200));
+		Files.delete(b.getPath("/y"));
+
+		a.replicate(b);
+		b.replicate(a);
+
+		// 200 > 100: the deletion wins on both, and the replicas converge
+		assertFalse(Files.exists(a.getPath("/y")));
+		assertFalse(Files.exists(b.getPath("/y")));
+		assertEquals(a.getRootHash(), b.getRootHash());
+	}
+
+	/** Merge order does not matter: bidirectional replication converges to one canonical tree. */
+	@Test
+	public void testMergeConverges() throws IOException {
+		DLFSLocal a = DLFS.create();
+		DLFSLocal b = DLFS.create();
+
+		a.setTimestamp(CVMLong.create(10));
+		Files.createDirectory(a.getPath("/d"));
+		Files.write(a.getPath("/d/keep"), new byte[] { 1 });
+		Files.write(a.getPath("/gone"), new byte[] { 2 });
+
+		b.replicate(a); // both share the baseline
+
+		a.setTimestamp(CVMLong.create(20));
+		Files.delete(a.getPath("/gone"));       // A deletes gone
+		b.setTimestamp(CVMLong.create(20));
+		Files.write(b.getPath("/d/added"), new byte[] { 3 }); // B adds a file concurrently
+
+		a.replicate(b);
+		b.replicate(a);
+
+		assertEquals(a.getRootHash(), b.getRootHash());
+		assertFalse(Files.exists(a.getPath("/gone")));
+		assertTrue(Files.exists(a.getPath("/d/keep")));
+		assertTrue(Files.exists(a.getPath("/d/added")));
+	}
+}

--- a/convex-dlfs/docs/DLFS_DESIGN.md
+++ b/convex-dlfs/docs/DLFS_DESIGN.md
@@ -222,8 +222,12 @@ Child entries are included when `Depth: 1` is requested.
 deterministically as `max(getUTime(a), getUTime(b))` — no external timestamp needed.
 
 - **Files**: Newer timestamp wins. Equal timestamps: `a` preferred.
-- **Directories**: Entries merged recursively via `Index.mergeDifferences()`.
-- **Tombstones**: A tombstone with a newer timestamp than a file deletes it.
+- **Directories**: Live entries merged recursively via `Index.mergeDifferences()`.
+- **Tombstones**: A directory node keeps deletions in a separate tombstone index
+  (deleted child name → deletion timestamp), held as an optional 5th node element that
+  is present only when non-empty (the default node stays 4 elements). Live entries and
+  tombstones are merged independently, then reconciled: a tombstone whose timestamp is
+  newer than (or equal to) a live child deletes it; a newer creation resurrects the name.
 - **Commutativity**: `merge(a, b) == merge(b, a)` (same inputs → same output).
 - **Idempotency**: `merge(a, a) == a`.
 


### PR DESCRIPTION
## Summary

Three commits that make `Index.mergeDifferences` divergence-proportional and rework DLFS tombstones to use it, so listing/working with active files is O(live) rather than O(live + deleted).

### 1. `perf(core)`: structural radix merge for `Index.mergeDifferences`
Replaces the O(n_a + n_b) double-scan with a recursive radix-trie merge that skips identical (or value-equal, via `Ref` equality) sub-tries in O(1) and shares them, so cost and allocation are proportional to the **divergence** between the two indexes, not their total size. Returns the left argument by reference identity on a no-op.

Verified **bit-identical to the previous naive algorithm** for all inputs and merge functions by a differential fuzz (300 cases × 5 functions) using the old algorithm as the oracle, plus commutativity, disjoint/nested-prefix, and `assertSame` no-op cases. Semantically equivalent to `MapTree`/`MapLeaf.mergeDifferences`, adapted to the radix structure (which adds path-compression cases — disjoint/nested — with no HAMT analog).

### 2. `refactor(dlfs)`: store tombstones in a separate per-directory index
Deletions move out of the live directory entries into a separate tombstone index (deleted child name → deletion timestamp), appended to a directory node as an optional 5th element **present only when non-empty**. The default node stays 4 elements, so existing drives load unchanged (no migration).

- Live filesystem operations (listing, emptiness, count, navigation) touch only live children with no tombstone filtering.
- Tombstones are no longer nodes — a deleted child is simply absent, which collapses the `isTombstone` read-path checks.
- Merge splits into independent structural merges of live entries (recursive) and tombstones (max timestamp), then reconciles create-vs-delete conflicts over the touched (divergence) set: a deletion newer than or equal to a live child wins; a newer creation resurrects the name. Result is normalised to canonical 4/5-element form, and `checkForeign` rejects a non-canonical empty tombstone element.

New `DLFSTombstoneTest` covers the canonical node-shape transitions and create-vs-delete reconciliation in both directions with replica convergence.

### 3. `test(core)`: document and assert the no-op identity contract
Makes the reference-identity return an explicit, binding contract on `AMap.mergeDifferences` / `Index.mergeDifferences` (callers may rely on `result == this` to detect "no change"), backed by a property test asserting `assertSame` across random radix structures for self-merge, an independently-built equal copy, an empty operand, and a random subset (aligned + nested), plus a directed nested case.

## Testing
- convex-core: **2135 tests pass**
- convex-dlfs (WebDAV): **68 pass**
- convex-gui: compiles

## Note (pre-existing, not changed here)
Writing to a file updates only its data and the parent dir timestamp, not the file node's own `POS_UTIME`, so a file's merge timestamp reflects creation rather than last write (true under the old design too). Recreation gets a fresh timestamp and wins as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)