### PR TITLE
fix(security): bind UCAN JWT verification to the iss key, not the kid header

### DIFF
--- a/convex-core/src/main/java/convex/auth/jwt/JWT.java
+++ b/convex-core/src/main/java/convex/auth/jwt/JWT.java
@@ -141,8 +141,16 @@ public class JWT {
 	// ========== Instance verification methods ==========
 
 	/**
-	 * Verify this JWT as a self-issued EdDSA token.
-	 * Extracts the public key from the {@code kid} header (multikey format).
+	 * Verify this JWT as a self-issued EdDSA token, taking the public key from the
+	 * {@code kid} header (multikey format).
+	 *
+	 * <p><b>SECURITY WARNING:</b> this trusts the {@code kid} header to supply the
+	 * verification key, so a valid result only proves "signed by whoever is named in
+	 * {@code kid}" — which the sender chooses. Do NOT use this where an identity claim
+	 * ({@code iss}, {@code sub}, ...) is trusted unless you separately bind that claim to
+	 * the signing key (e.g. require {@code sub == did:key(kid)}). For tokens whose identity
+	 * is itself a key (did:key), verify against the key derived from that claim using
+	 * {@link #verifyEdDSA(AccountKey)} instead.</p>
 	 *
 	 * @return true if signature is valid
 	 */
@@ -373,6 +381,12 @@ public class JWT {
 	 *
 	 * Extracts the public key from the {@code kid} header parameter (multikey format),
 	 * verifies the Ed25519 signature, and returns the parsed claims map.
+	 *
+	 * <p><b>SECURITY WARNING:</b> the {@code kid} header is sender-controlled, so this only
+	 * proves the token was signed by the key named in {@code kid}. Do NOT trust any identity
+	 * claim from the returned map unless you bind it to the signing key. Prefer
+	 * {@link #verifyPublic(AString, AccountKey)} against a key you trust out-of-band, or the
+	 * key derived from the identity claim itself. See {@link #verifyEdDSA()}.</p>
 	 *
 	 * @param jwt The encoded JWT string
 	 * @return Claims map if signature is valid, or null if verification fails

--- a/convex-core/src/main/java/convex/auth/ucan/UCAN.java
+++ b/convex-core/src/main/java/convex/auth/ucan/UCAN.java
@@ -398,20 +398,23 @@ public class UCAN {
 		JWT parsed = JWT.parse(jwtString);
 		if (parsed == null) return null;
 
-		// Verify signature via kid header
-		if (!parsed.verifyEdDSA()) return null;
-
 		AMap<AString, ACell> claims = parsed.getClaims();
 		if (claims == null) return null;
 
-		// Extract issuer key for internal use
-		AString issuerDID = RT.ensureString(claims.get(ISS));
-		AccountKey issuerKey = fromDIDKey(issuerDID);
+		// Derive the verification key from the `iss` DID (did:key encodes the issuer's
+		// public key) and verify the signature against THAT key.
+		//
+		// SECURITY: the verification key MUST be bound to the claimed issuer. The JWT `kid`
+		// header is attacker-controlled and must not select the verification key — otherwise
+		// an attacker could sign with their own key, name it in `kid`, and forge any `iss`
+		// (issuer spoofing / authorization bypass). For a did:key UCAN the issuer IS the key,
+		// so we ignore `kid` and verify directly against the iss key.
+		AccountKey issuerKey = fromDIDKey(RT.ensureString(claims.get(ISS)));
 		if (issuerKey == null) return null;
+		if (!parsed.verifyEdDSA(issuerKey)) return null;
 
-		// Build the signature from the JWT's raw bytes
-		// We store the JWT's signature but note: verifySignature() uses CAD3,
-		// so for JWT-parsed tokens use verifyJWT() instead
+		// Build the signature from the JWT's raw bytes. Note: verifySignature() uses CAD3,
+		// so for JWT-parsed tokens use the JWT verification path, not verifySignature().
 		ASignature sig = ASignature.fromBlob(Blob.wrap(parsed.getSignatureBytes()));
 
 		return new UCAN(claims, sig);

--- a/convex-core/src/test/java/convex/auth/ucan/UCANTest.java
+++ b/convex-core/src/test/java/convex/auth/ucan/UCANTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
+import convex.auth.jwt.JWT;
 import convex.core.crypto.AKeyPair;
 import convex.core.data.ACell;
 import convex.core.data.AMap;
@@ -452,6 +453,83 @@ public class UCANTest {
 		assertNull(UCAN.fromJWT(null));
 		assertNull(UCAN.fromJWT(Strings.create("not.a.jwt")));
 		assertNull(UCAN.fromJWT(Strings.create("")));
+	}
+
+	// ===== Adversarial: issuer spoofing via mismatched kid =====
+	//
+	// A did:key UCAN's issuer IS its key, so verification must be bound to the `iss`
+	// claim — never to the attacker-controlled `kid` header. These tests forge a token
+	// that claims iss=ROOT but is actually signed by ROGUE (whose key lands in kid), and
+	// assert it is rejected at every layer. They fail against kid-based verification.
+
+	/** A JWT claiming {@code iss=spoofedIssuer} but actually signed by {@code signer} (kid = signer's key). */
+	private static AString forgeIssuer(AccountKey spoofedIssuer, AKeyPair signer, AccountKey aud,
+			long exp, AVector<ACell> caps) {
+		AMap<AString, ACell> claims = UCAN.buildPayload(spoofedIssuer, aud, exp, null, caps, null, null);
+		return JWT.signPublic(claims, signer); // signs with `signer`; kid header = signer's key
+	}
+
+	@Test
+	public void testJWTIssuerSpoofRejectedAtParse() {
+		AString forged = forgeIssuer(ROOT_KP.getAccountKey(), ROGUE_KP, ROGUE_KP.getAccountKey(),
+			FUTURE_EXPIRY, oneCap("w/secret", Capability.TOP));
+		assertNull(UCAN.fromJWT(forged),
+			"JWT claiming iss=ROOT but signed by another key (named in kid) must be rejected");
+	}
+
+	@Test
+	public void testJWTIssuerSpoofRejectedAtValidate() {
+		AString forged = forgeIssuer(ROOT_KP.getAccountKey(), ROGUE_KP, ROGUE_KP.getAccountKey(),
+			FUTURE_EXPIRY, oneCap("w/secret", Capability.TOP));
+		assertNull(UCANValidator.validateJWT(forged, NOW));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testJWTIssuerSpoofDroppedAtTransportBoundary() {
+		AString forged = forgeIssuer(ROOT_KP.getAccountKey(), ROGUE_KP, ROGUE_KP.getAccountKey(),
+			FUTURE_EXPIRY, oneCap("w/secret", Capability.TOP));
+		// Forgery alone: nothing passes the trust boundary
+		assertNull(UCANValidator.parseTransportUCANs(Vectors.of(forged)),
+			"Spoofed-issuer token must not pass the transport trust boundary");
+
+		// Mixed with a genuine ROOT->ROGUE grant: only the genuine token survives, and the
+		// forged ROOT capability is never attributed to ROOT through the end-to-end path.
+		AString genuine = UCAN.createJWT(ROOT_KP, ROGUE_KP.getAccountKey(), FUTURE_EXPIRY,
+			oneCap("w/health", Capability.CRUD_READ), null);
+		AVector<ACell> verified = UCANValidator.parseTransportUCANs(Vectors.of(forged, genuine));
+		assertNotNull(verified);
+		assertEquals(1L, verified.count(), "only the genuinely-signed token survives");
+
+		AString rogueDID = UCAN.toDIDKey(ROGUE_KP.getAccountKey());
+		AVector<ACell> caps = UCANValidator.capabilitiesFor(verified, rogueDID, ROOT_DID, NOW);
+		assertNotNull(caps);
+		assertEquals(1L, caps.count());
+		assertFalse(Capability.covers((AMap<AString, ACell>) caps.get(0), "w/secret/x", "crud/write"),
+			"forged ROOT-issued capability must not appear");
+	}
+
+	@Test
+	public void testJWTSpoofedProofInChainRejected() {
+		// A genuine child (AGENT_A -> AGENT_B) whose proof is a forged ROOT token (claims
+		// iss=ROOT but actually signed by ROGUE). The chain must fail to validate.
+		AString forgedProof = forgeIssuer(ROOT_KP.getAccountKey(), ROGUE_KP, AGENT_A_KP.getAccountKey(),
+			FUTURE_EXPIRY, oneCap("w/secret", Capability.TOP));
+		AString child = UCAN.createJWT(AGENT_A_KP, AGENT_B_KP.getAccountKey(), FUTURE_EXPIRY,
+			null, Vectors.of(forgedProof));
+		assertNull(UCANValidator.validateJWT(child, NOW),
+			"A chain whose proof spoofs its issuer must be rejected");
+	}
+
+	@Test
+	public void testGenuineJWTStillVerifiesAfterFix() {
+		// Regression: the fix must not break legitimately-signed tokens (kid == iss key).
+		AString genuine = UCAN.createJWT(ROOT_KP, AGENT_A_KP.getAccountKey(), FUTURE_EXPIRY,
+			oneCap("w/health", Capability.CRUD_READ), null);
+		UCAN parsed = UCAN.fromJWT(genuine);
+		assertNotNull(parsed);
+		assertEquals(ROOT_DID, parsed.getIssuer());
+		assertNotNull(UCANValidator.validateJWT(genuine, NOW));
 	}
 
 	// ===== checkTemporalBounds =====


### PR DESCRIPTION
## Vulnerability

`UCAN.fromJWT` verified the EdDSA signature against the public key named in the **attacker-controlled `kid` header**, then trusted the `iss` claim without checking the two agree. An attacker could sign a token with their own key, place that key in `kid`, and claim any `iss` (e.g. a trusted root) — an **issuer-spoofing authorization bypass**.

The forged token passed `validateJWT` / `parseTransportUCANs`, and via `UCANValidator.capabilitiesFor(..., issuer=root)` yielded capabilities attributed to the root. Reachable from transport input (e.g. `DlfsMcpTools`).

## Fix

Derive the verification key from the `iss` DID (`did:key` encodes the issuer's public key) and verify against it. The `kid` header is no longer trusted for key selection. Legitimately signed tokens are unaffected (`kid` already equals the `iss` key). The CAD3 path (`UCAN.verifySignature` / `validate`) was already correct.

## Audit of other JWT verification paths

| Path | Verdict |
|------|---------|
| `UCAN.fromJWT` | was vulnerable → fixed |
| `PeerAuth.verifySelfIssued` | safe — binds `sub == did:key(kid)` (covered by `testSelfIssuedJWTKidMismatch`, `testBadlySignedJWTWithCorrectAudience`) |
| `PeerAuth.verifyPeerSigned` | safe (verifies against trusted peer key) |
| `OAuthService` (JWKS RS256) | safe (`kid` selects among the provider's trusted keys; `iss`/`aud` validated) |
| `JWKSKeys` | safe (parser only) |

Added a `SECURITY WARNING` to the `kid`-trusting `JWT.verifyEdDSA()` / `verifyPublic(jwt)` to prevent reintroduction.

## Adversarial tests

`UCANTest` now forges `iss=ROOT` signed by a rogue key and asserts rejection at `fromJWT`, `validateJWT`, the transport boundary (`parseTransportUCANs` → `capabilitiesFor`), and inside a proof chain; plus a regression that genuine tokens still verify. These four were confirmed to **fail against the pre-fix `kid`-based verification** (the forged token was accepted as `iss=ROOT` granting `can:"*"`), then pass after the fix.

## Testing
- convex-core: 2131 pass
- convex-peer (`PeerAuthTest`): 20 pass
- convex-dlfs: 68 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)