### PR TITLE
fix(security): boundary-aware Capability.resourceCovers + fail-closed empty `with` (#585)

### DIFF
--- a/convex-core/src/main/java/convex/auth/ucan/Capability.java
+++ b/convex-core/src/main/java/convex/auth/ucan/Capability.java
@@ -91,11 +91,10 @@ public class Capability {
 			AString requestWith, AString requestCan) {
 		if (grantCan == null || requestCan == null) return false;
 
-		// Resource attenuation
-		if (grantWith != null && requestWith != null) {
-			if (!resourceCovers(grantWith, requestWith)) return false;
-		}
-		// null grantWith = any resource (wildcard)
+		// Resource attenuation. Fail-closed: a grant with no resource pointer (null/empty
+		// `with`) covers nothing — absence is NOT a resource wildcard. Resource wildcards
+		// must be explicit, never implied by a missing/truncated capability.
+		if (!resourceCovers(grantWith, requestWith)) return false;
 
 		// Ability attenuation
 		return abilityCovers(grantCan, requestCan);
@@ -104,33 +103,40 @@ public class Capability {
 	/**
 	 * Checks whether a granted resource path covers a requested resource path.
 	 *
-	 * <p>Uses path prefix matching with boundary awareness:</p>
+	 * <p>Uses path prefix matching with path-segment boundary awareness:</p>
 	 * <ul>
 	 *   <li>Exact match: {@code "w/decisions"} covers {@code "w/decisions"}</li>
-	 *   <li>Prefix: {@code "w/decisions"} covers {@code "w/decisions/INV-123"}</li>
+	 *   <li>Prefix at a segment boundary: {@code "w/decisions"} covers {@code "w/decisions/INV-123"},
+	 *       but NOT the sibling {@code "w/decisions-secret"}</li>
 	 *   <li>Trailing slash: {@code "w/decisions/"} covers {@code "w/decisions"} and children</li>
-	 *   <li>Empty grant covers any resource</li>
 	 * </ul>
+	 *
+	 * <p><b>Fail-closed:</b> a null or empty {@code grant} or {@code request} covers nothing.
+	 * An absent/empty resource pointer is never a wildcard.</p>
 	 */
 	public static boolean resourceCovers(AString grant, AString request) {
-		if (grant == null) return true;
-		if (request == null) return true;
+		// Fail-closed: a missing or empty resource pointer grants nothing (not a wildcard).
+		if (grant == null || request == null) return false;
 
 		long gLen = grant.count();
 		long rLen = request.count();
-
-		// Empty grant covers everything
-		if (gLen == 0) return true;
+		if (gLen == 0 || rLen == 0) return false;
 
 		// Exact match (interned strings may be identical objects)
 		if (grant.equals(request)) return true;
 
-		// Check if request starts with grant
-		if (rLen > gLen && request.startsWith(grant)) return true;
+		// Trailing-slash grant: "w/records/" also covers the bare parent "w/records"
+		if (grant.charAt(gLen - 1) == '/' && rLen == gLen - 1
+				&& request.equals(grant.slice(0, gLen - 1))) {
+			return true;
+		}
 
-		// Trailing slash: "w/records/" covers "w/records"
-		if (gLen > 0 && grant.charAt(gLen - 1) == '/' && rLen == gLen - 1) {
-			if (request.equals(grant.slice(0, gLen - 1))) return true;
+		// Prefix, but only at a path-segment boundary, so "w/notes" covers "w/notes/x" but NOT
+		// the sibling "w/notesSECRET". The boundary holds when the grant already ends with '/',
+		// or the next character in the request is '/'.
+		if (rLen > gLen && request.startsWith(grant)
+				&& (grant.charAt(gLen - 1) == '/' || request.charAt(gLen) == '/')) {
+			return true;
 		}
 
 		return false;

--- a/convex-core/src/test/java/convex/auth/ucan/CapabilityTest.java
+++ b/convex-core/src/test/java/convex/auth/ucan/CapabilityTest.java
@@ -109,18 +109,41 @@ public class CapabilityTest {
 	}
 
 	@Test
-	public void testResourceNullGrantCoversAll() {
-		assertTrue(Capability.resourceCovers(null, Strings.create("w/anything")));
+	public void testResourceNullGrantFailsClosed() {
+		// A grant with no resource pointer covers nothing — absence is not a wildcard (#585).
+		assertFalse(Capability.resourceCovers(null, Strings.create("w/anything")));
 	}
 
 	@Test
-	public void testResourceEmptyGrantCoversAll() {
-		assertTrue(Capability.resourceCovers(Strings.create(""), Strings.create("w/anything")));
+	public void testResourceEmptyGrantFailsClosed() {
+		assertFalse(Capability.resourceCovers(Strings.create(""), Strings.create("w/anything")));
 	}
 
 	@Test
-	public void testResourceNullRequestAllowed() {
-		assertTrue(Capability.resourceCovers(Strings.create("w/data"), null));
+	public void testResourceNullRequestFailsClosed() {
+		assertFalse(Capability.resourceCovers(Strings.create("w/data"), null));
+	}
+
+	@Test
+	public void testResourceEmptyRequestFailsClosed() {
+		assertFalse(Capability.resourceCovers(Strings.create("w/data"), Strings.create("")));
+	}
+
+	// ----- Adversarial: path-segment boundary (attenuation escape, #585) -----
+
+	@Test
+	public void testResourceSiblingNotCovered() {
+		// A grant on "w/notes" must NOT cover siblings that merely share the string prefix.
+		assertFalse(Capability.resourceCovers(Strings.create("w/notes"), Strings.create("w/notesSECRET")));
+		assertFalse(Capability.resourceCovers(Strings.create("w/report"), Strings.create("w/report-confidential")));
+		assertFalse(Capability.resourceCovers(Strings.create("w/report"), Strings.create("w/reports")));
+	}
+
+	@Test
+	public void testResourceChildStillCoveredAtBoundary() {
+		// But it MUST still cover genuine path children and the exact resource.
+		assertTrue(Capability.resourceCovers(Strings.create("w/report"), Strings.create("w/report/2024")));
+		assertTrue(Capability.resourceCovers(Strings.create("w/report"), Strings.create("w/report")));
 	}
 
 	// ========== Full covers (AString) ==========
@@ -177,13 +200,22 @@ public class CapabilityTest {
 	}
 
 	@Test
-	public void testCoversStringWildcard() {
-		assertTrue(Capability.covers("", "*", "w/anything", "crud/write"));
+	public void testCoversEmptyWithFailsClosed() {
+		// An empty grant resource must not become an all-resources grant, even with TOP ability (#585).
+		assertFalse(Capability.covers("", "*", "w/anything", "crud/write"));
 	}
 
 	@Test
-	public void testCoversStringNull() {
-		assertTrue(Capability.covers((String) null, "*", "w/anything", "crud/read"));
+	public void testCoversNullWithFailsClosed() {
+		assertFalse(Capability.covers((String) null, "*", "w/anything", "crud/read"));
+	}
+
+	@Test
+	public void testCoversSiblingResourceEscapeBlocked() {
+		// crud/read on "w/report" must not reach the sibling "w/report-confidential" (#585).
+		assertFalse(Capability.covers("w/report", "crud/read", "w/report-confidential", "crud/read"));
+		// but still covers the genuine child
+		assertTrue(Capability.covers("w/report", "crud/read", "w/report/q3", "crud/read"));
 	}
 
 	// ========== DID URL resources ==========


### PR DESCRIPTION
Fixes #585.

## Vulnerability

`Capability.resourceCovers` matched a granted resource against a requested one with a raw `startsWith` and **no path-segment boundary**, so a grant on `w/notes` also covered siblings like `w/notesSECRET` / `w/report-confidential` — a **UCAN attenuation / delegation escape** (cross-tenant over-read/over-write where delegation is used). Separately, a null/empty `with` was treated as **"covers every resource"** (fail-open), turning a malformed or truncated capability into a superuser grant.

This is the companion to #586 (the JWT issuer-spoofing fix): #586 made the token layer sound; this makes the authorization-decision layer underneath it sound.

## Fix

- `resourceCovers` now requires a **path-segment boundary** on the prefix branch (mirroring the already-correct `abilityCovers`): the prefix matches only when the grant ends with `/` or the next char in the request is `/`. Exact-match and trailing-slash-parent are preserved; genuine children (`w/notes/x`) still match.
- Both `resourceCovers` and `covers` now **fail closed** on null/empty grant or request `with`. An absent resource pointer is never a wildcard.

| grant | request | before | after |
|---|---|---|---|
| `w/notes` | `w/notes/child` | true | ✅ true |
| `w/notes` | `w/notesSECRET` | **true** | ✅ **false** |
| `""` / null | `w/anything` | **true** | ✅ **false** |

## Tests

`CapabilityTest` gains adversarial sibling-escape and empty/null-`with` superuser cases, plus genuine-child/exact regressions. The five existing tests that asserted the fail-open behaviour are flipped to expect fail-closed. **Confirmed all seven adversarial assertions fail against the pre-fix code.**

convex-core: 2135 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)