### PR TITLE
harden(dlfs): fail-safe lattice merge against malformed foreign nodes

### DIFF
--- a/convex-core/src/main/java/convex/lattice/fs/DLFSLattice.java
+++ b/convex-core/src/main/java/convex/lattice/fs/DLFSLattice.java
@@ -8,6 +8,7 @@ import convex.core.data.prim.AInteger;
 import convex.core.data.prim.CVMLong;
 import convex.core.util.Utils;
 import convex.lattice.ALattice;
+import convex.lattice.LatticeContext;
 import convex.lattice.generic.IndexLattice;
 
 /**
@@ -46,10 +47,7 @@ public class DLFSLattice extends ALattice<AVector<ACell>> {
 	public AVector<ACell> merge(AVector<ACell> ownValue, AVector<ACell> otherValue) {
 		// Handle null cases
 		if (ownValue == null) {
-			if (checkForeign(otherValue)) {
-				return otherValue;
-			}
-			return zero();
+			return checkForeign(otherValue) ? otherValue : zero();
 		}
 		if (otherValue == null) {
 			return ownValue;
@@ -60,34 +58,39 @@ public class DLFSLattice extends ALattice<AVector<ACell>> {
 			return ownValue;
 		}
 
-		// Delegate to DLFSNode.merge which implements the rsync-like merge logic
-		// The merge is deterministic: timestamp is derived from the input nodes
-		return DLFSNode.merge(ownValue, otherValue);
+		return safeMerge(ownValue, otherValue);
 	}
 
 	@Override
-	public AVector<ACell> merge(convex.lattice.LatticeContext context, AVector<ACell> ownValue, AVector<ACell> otherValue) {
-		// Handle null cases
+	public AVector<ACell> merge(LatticeContext context, AVector<ACell> ownValue, AVector<ACell> otherValue) {
+		// Context timestamp is not used for DLFS merge — the merge is deterministic from
+		// the input nodes — so this behaves identically to the no-context overload.
 		if (ownValue == null) {
-			if (checkForeign(otherValue)) {
-				return otherValue;
-			}
-			return zero();
+			return checkForeign(otherValue) ? otherValue : zero();
 		}
 		if (otherValue == null) {
 			return ownValue;
 		}
-
-		// Fast path: if values are equal, return own value
 		if (Utils.equals(ownValue, otherValue)) {
 			return ownValue;
 		}
+		return safeMerge(ownValue, otherValue);
+	}
 
-		// Delegate to DLFSNode.merge which implements the rsync-like merge logic
-		// The merge is deterministic: timestamp is derived from the input nodes
-		// Note: Context timestamp is currently not used for DLFS merge.
-		// If timestamp override is needed, it should be handled at a higher level.
-		return DLFSNode.merge(ownValue, otherValue);
+	/**
+	 * Fail-safe merge of two non-null, unequal nodes. {@code other} may originate from an
+	 * untrusted peer; rather than pre-validating its structure, the merge is attempted and
+	 * falls closed to {@code own} if a malformed node makes it throw. A malformed value can
+	 * therefore neither crash the merge (DoS) nor corrupt the merged state — it is ignored.
+	 */
+	private AVector<ACell> safeMerge(AVector<ACell> own, AVector<ACell> other) {
+		try {
+			return DLFSNode.merge(own, other);
+		} catch (RuntimeException e) {
+			// Malformed / adversarial foreign node: fail closed and keep own, rather than
+			// letting a bad value from an untrusted peer crash or corrupt the merge.
+			return own;
+		}
 	}
 
 	@Override

--- a/convex-core/src/test/java/convex/lattice/fs/DLFSTombstoneTest.java
+++ b/convex-core/src/test/java/convex/lattice/fs/DLFSTombstoneTest.java
@@ -2,11 +2,13 @@ package convex.lattice.fs;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -15,7 +17,9 @@ import convex.core.data.AString;
 import convex.core.data.AVector;
 import convex.core.data.Index;
 import convex.core.data.Strings;
+import convex.core.data.Vectors;
 import convex.core.data.prim.CVMLong;
+import convex.lattice.LatticeContext;
 import convex.lattice.fs.impl.DLFSLocal;
 
 /**
@@ -132,5 +136,31 @@ public class DLFSTombstoneTest {
 		assertFalse(Files.exists(a.getPath("/gone")));
 		assertTrue(Files.exists(a.getPath("/d/keep")));
 		assertTrue(Files.exists(a.getPath("/d/added")));
+	}
+
+	/**
+	 * A malformed foreign node from an untrusted peer must not crash or corrupt the merge:
+	 * the merge fails closed to {@code own} rather than throwing.
+	 */
+	@Test
+	public void testMergeFailsSafeOnMalformedNode() {
+		DLFSLattice lat = DLFSLattice.INSTANCE;
+
+		// A valid own directory with one live child
+		Index<AString, AVector<ACell>> ownEntries =
+			Index.of(Strings.create("f"), DLFSNode.createEmptyFile(CVMLong.create(1)));
+		AVector<ACell> own = Vectors.of(ownEntries, null, null, CVMLong.create(1));
+
+		AVector<ACell> tooShort = Vectors.of(CVMLong.ZERO);                                        // missing slots
+		AVector<ACell> badUtime = Vectors.of(Index.none(), null, null, Strings.create("nope"));    // POS_UTIME not a long
+		AVector<ACell> badDir   = Vectors.of(Strings.create("x"), null, null, CVMLong.create(2));  // POS_DIR not an Index
+		Index<AString, AVector<ACell>> badEntries =
+			Index.of(Strings.create("f"), Vectors.of(Strings.create("x")));                        // malformed child node
+		AVector<ACell> deepBad  = Vectors.of(badEntries, null, null, CVMLong.create(2));
+
+		for (AVector<ACell> bad : List.of(tooShort, badUtime, badDir, deepBad)) {
+			assertSame(own, lat.merge(own, bad), "malformed foreign node must be rejected, keeping own");
+			assertSame(own, lat.merge((LatticeContext) null, own, bad), "context merge must also fail safe");
+		}
 	}
 }


### PR DESCRIPTION
## Problem

`DLFSLattice.merge` called `DLFSNode.merge` directly on the both-non-null path, and `checkForeign` was only enforced when `own` was null. So a malformed node from an **untrusted peer** (wrong-typed `POS_UTIME`/`POS_DIR`, a too-short vector, or a malformed child deep in the tree) could throw during the recursive merge and crash it — a DoS vector on the network propagation path.

## Fix

Wrap the recursive merge in a fail-closed `safeMerge`: attempt `DLFSNode.merge`, and on any `RuntimeException` keep `own`. No expensive up-front validation (which would mean walking the whole tree); we simply let a malformed node throw and reject it. A bad value from an untrusted peer can therefore neither crash the merge nor corrupt the merged state — it is ignored. Both `merge` overloads share the path.

## Test

`DLFSTombstoneTest.testMergeFailsSafeOnMalformedNode` feeds too-short, bad-`utime`, non-`Index`-dir, and deep-malformed-child nodes through both merge overloads and asserts the merge keeps `own` (`assertSame`) without throwing.

Relates to #561/#562 (untrusted-peer merge hardening). convex-core: 2145 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)