### PR TITLE
chore(deps): bump stable dependencies

### DIFF
--- a/convex-core/pom.xml
+++ b/convex-core/pom.xml
@@ -158,7 +158,7 @@
 	    <dependency>
 	      <groupId>org.javassist</groupId>
 	      <artifactId>javassist</artifactId>
-	      <version>3.30.2-GA</version>   <!-- clean, modern, no broken systemPath -->
+	      <version>3.32.0-GA</version>   <!-- clean, modern, no broken systemPath -->
 	    </dependency>
 	  </dependencies>
 	</dependencyManagement>

--- a/convex-db/pom.xml
+++ b/convex-db/pom.xml
@@ -16,7 +16,7 @@
 	<url>https://convex.world</url>
 
 	<properties>
-		<calcite.version>1.41.0</calcite.version>
+		<calcite.version>1.42.0</calcite.version>
 	</properties>
 
 	<build>

--- a/convex-dlfs/pom.xml
+++ b/convex-dlfs/pom.xml
@@ -26,7 +26,7 @@
 		<dependency>
 			<groupId>com.github.lookfirst</groupId>
 			<artifactId>sardine</artifactId>
-			<version>5.12</version>
+			<version>5.13</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/convex-gui/pom.xml
+++ b/convex-gui/pom.xml
@@ -16,7 +16,7 @@
 	
 	<properties>
 		<zxing.version>3.5.4</zxing.version>
-		<flatlaf.version>3.7</flatlaf.version>
+		<flatlaf.version>3.7.1</flatlaf.version>
 	</properties>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<logback.version>1.5.32</logback.version>
 		<jmh.version>1.37</jmh.version>
-		<junit.version>6.0.1</junit.version>
+		<junit.version>6.1.0</junit.version>
 		<slf4j.version>2.0.16</slf4j.version>
 		<hc.version>5.5</hc.version>
 		<netty.version>4.2.7.Final</netty.version>


### PR DESCRIPTION
Stable dependency updates, taken early in the `0.8.7-SNAPSHOT` cycle:

| Dependency | Bump | Scope |
|---|---|---|
| JUnit Jupiter/Platform | `6.0.1 → 6.1.0` | test |
| Javassist | `3.30.2-GA → 3.32.0-GA` | runtime |
| Sardine | `5.12 → 5.13` | DLFS WebDAV test |
| FlatLaf + intellij-themes | `3.7 → 3.7.1` | GUI |
| Calcite core/server | `1.41.0 → 1.42.0` | convex-db |

**Intentionally skipped:** Netty `5.0.0.Alpha2` and SLF4J `2.1.0-alpha1` (alpha pre-releases — current versions are the latest stable), and MCP SDK `2.0.0` (breaking major, needs a dedicated migration).

Full reactor build + tests pass across all 12 modules. No CHANGELOG entry (dependency bumps, per convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)