### PR TITLE
Fix AIndex.entrySet() losing sorted key order via HashSet

### DIFF
--- a/convex-core/src/main/java/convex/core/data/AIndex.java
+++ b/convex-core/src/main/java/convex/core/data/AIndex.java
@@ -1,7 +1,7 @@
 package convex.core.data;
 
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import convex.core.data.type.AType;
@@ -49,9 +49,13 @@ public abstract class AIndex<K extends ABlobLike<?>, V extends ACell> extends AM
 	 */
 	public abstract V get(K key);
 
+	// entryAt(i) walks the radix tree in ascending key order, so a
+	// LinkedHashSet (which preserves insertion order) is needed here to keep
+	// that ordering visible through entrySet() — a plain HashSet iterates in
+	// hash-bucket order and silently discards it (#651).
 	@Override
 	public Set<Entry<K, V>> entrySet() {
-		HashSet<Entry<K,V>> hs=new HashSet<>(size());
+		LinkedHashSet<Entry<K,V>> hs=new LinkedHashSet<>(size());
 		long n=count();
 		for (long i=0; i<n; i++) {
 			MapEntry<K,V> me=entryAt(i);

--- a/convex-core/src/test/java/convex/core/data/IndexTest.java
+++ b/convex-core/src/test/java/convex/core/data/IndexTest.java
@@ -235,6 +235,27 @@ public class IndexTest {
 		doIndexTests(rm);
 	}
 	
+	/**
+	 * entrySet() must preserve the Index's sorted key order (#651) — the class
+	 * is documented as "a sorted radix-tree map... provide sorted orderings for
+	 * indexes", and callers commonly iterate entrySet() (e.g. `for (var e :
+	 * index.entrySet())`) expecting that guarantee to hold, not just entryAt(i).
+	 */
+	@Test
+	public void testEntrySetOrder() throws InvalidDataException {
+		Index<ABlob, CVMLong> m = Index.none();
+		for (int i = 0; i < 50; i++) {
+			m = m.assoc(LongBlob.create(i), RT.cvm((long) i));
+		}
+		assertEquals(50L, m.count());
+
+		java.util.Iterator<java.util.Map.Entry<ABlob, CVMLong>> it = m.entrySet().iterator();
+		for (long i = 0; i < m.count(); i++) {
+			assertEquals(m.entryAt(i), it.next(), "entrySet() order diverged from entryAt() sorted order");
+		}
+		assertFalse(it.hasNext());
+	}
+
 	@Test public void testContains() {
 		Index<ABlob, CVMLong> bm=Samples.INT_INDEX_256;
 		long n=bm.count;


### PR DESCRIPTION
Fixes #651.

## Problem

`AIndex` documents itself as "a sorted radix-tree map of Blobs to Values" whose primary benefit is to "provide sorted orderings for indexes." That guarantee holds for `entryAt(i)`, but not for `entrySet()`:

```java
@Override
public Set<Entry<K, V>> entrySet() {
    HashSet<Entry<K,V>> hs=new HashSet<>(size());
    long n=count();
    for (long i=0; i<n; i++) {
        MapEntry<K,V> me=entryAt(i);
        hs.add(me);
    }
    return Collections.unmodifiableSet(hs);
}
```

`entryAt(i)` walks the radix tree correctly in ascending key order, but the entries are collected into a `java.util.HashSet`, whose iteration order is hash-bucket-based, not insertion order. Any caller iterating `entrySet()` directly (or `keySet()`, `forEach`, an enhanced-for loop) — a reasonable thing to do given the class's documented sort guarantee — gets entries back in effectively arbitrary order instead.

## Fix

Swap `HashSet` for `LinkedHashSet`. Since `entryAt(i)` already inserts in correct ascending order for `i = 0..n-1`, a `LinkedHashSet` (which preserves insertion order) is sufficient to restore the documented guarantee — no other logic changes.

## Testing

Added `IndexTest.testEntrySetOrder()`, which builds a 50-entry `Index` and asserts `entrySet()`'s iteration order matches `entryAt(i)` for every `i`.

- Fails on the old `HashSet` implementation (confirmed locally: entry 0 expected, entry 49 observed at the same position)
- Passes with the `LinkedHashSet` fix
- Full `convex-core` suite: 2812 tests, 0 failures, 0 errors

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)