### PR TITLE
chore: upgrade org.apache.commons:commons-lang3 from 3_1 to 3_20_0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,16 @@
 		</argLine>
 	</properties>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-lang3</artifactId>
+				<version>3.20.0</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<licenses>
 		<license>
 			<name>Convex Public License</name>


### PR DESCRIPTION
Summary
Upgraded org.apache.commons:commons-lang3 from 3.1 to 3.20.0 in the Convex project.

The dependency was a transitive runtime dependency flowing through calcite-core:1.42.0 → uzaygezen-core:0.2 → commons-lang3:3.1. Version 3.1 had a security advisory (CVSS 6.5) and the recommended version 3.20.0 has 0 advisories.

Since commons-lang3 was not directly declared (purely transitive), I added it to the parent POM's <dependencyManagement> section with version 3.20.0. This overrides the transitive 3.1 version without changing any direct dependency declarations. The convex-db module is the only one affected by this transitive dependency, and its tests all pass.

The single test error in convex-peer (UpgradeWithdrawalTest.testLastPeerDoesNotWithdraw - timeout) is a pre-existing flaky test unrelated to this change (convex-peer does not depend on commons-lang3).

Notes
One pre-existing flaky test in convex-peer (UpgradeWithdrawalTest.testLastPeerDoesNotWithdraw - timeout) fails intermittently — unrelated to this change since convex-peer has no dependency on commons-lang3.