### PR TITLE
Fix silent, permanent lattice delivery failures in NodeServer/Acquiror

### DIFF
--- a/convex-peer/src/main/java/convex/api/Acquiror.java
+++ b/convex-peer/src/main/java/convex/api/Acquiror.java
@@ -155,8 +155,32 @@ public final class Acquiror implements AutoCloseable {
 		}
 	}
 
+	/**
+	 * Max consecutive request/response rounds tolerated where the response
+	 * contains a null (not-yet-available) value for a still-outstanding hash,
+	 * before giving up on this acquisition entirely. A single null response is
+	 * an ordinary, expected condition -- e.g. the peer answering has not yet
+	 * finished persisting the value, or the request raced a concurrent write
+	 * on the peer's side -- and typically self-resolves within milliseconds.
+	 * Treating it as immediately fatal (the previous behaviour) meant a single
+	 * transient hiccup during a periodic root-sync or delta broadcast turned
+	 * into a permanent, silent delivery failure: nothing ever retried that
+	 * specific hash again, and since a node's lattice root routes through the
+	 * same unresolved branch on every later update too, EVERY subsequent
+	 * broadcast referencing it failed identically, forever, until an operator
+	 * noticed and restarted the stuck node (which recovers via the unrelated,
+	 * always-retried {@code pullPath} full-sync path). Found diagnosing two
+	 * peer nodes that silently drifted apart indefinitely under ordinary
+	 * live traffic.
+	 */
+	private static final int MAX_NULL_RESPONSE_RETRIES = 10;
+
+	/** Delay between retries after a null (not-yet-available) response. */
+	private static final long NULL_RESPONSE_RETRY_DELAY_MS = 200;
+
 	private ACell acquire() throws Exception {
 		HashSet<Hash> missing = new HashSet<>();
+		int nullResponseRetries = 0;
 
 		while (!closed) {
 			Ref<ACell> ref = store.refForHash(hash);
@@ -189,13 +213,34 @@ public final class Acquiror implements AutoCloseable {
 				currentRequest = null;
 			}
 			if (closed) throw new CancellationException("Acquisition closed");
-			acceptResponse(requested, result);
+
+			Hash firstNullHash = acceptResponse(requested, result);
+			if (firstNullHash == null) {
+				nullResponseRetries = 0;
+			} else {
+				nullResponseRetries++;
+				if (nullResponseRetries > MAX_NULL_RESPONSE_RETRIES) {
+					throw new MissingDataException(store, firstNullHash);
+				}
+				log.debug("Acquisition got a null/not-yet-available response acquiring {} (root {}), retrying ({}/{})",
+					firstNullHash, hash, nullResponseRetries, MAX_NULL_RESPONSE_RETRIES);
+				if (closed) throw new CancellationException("Acquisition closed");
+				Thread.sleep(NULL_RESPONSE_RETRY_DELAY_MS);
+			}
 		}
 
 		throw new CancellationException("Acquisition closed");
 	}
 
-	private void acceptResponse(Hash[] requested, Result result)
+	/**
+	 * Stores every non-null value from the response. Returns the first
+	 * requested hash whose value came back null, or null if every requested
+	 * hash was present -- the caller retries a bounded number of times on a
+	 * null return before treating it as a genuine failure (see
+	 * {@link #MAX_NULL_RESPONSE_RETRIES}'s javadoc for why this isn't treated
+	 * as immediately fatal).
+	 */
+	private Hash acceptResponse(Hash[] requested, Result result)
 			throws BadFormatException, IOException, ResultException {
 		if (result == null) throw new BadFormatException("Missing acquisition result");
 		if (result.isError()) throw new ResultException(result);
@@ -203,16 +248,20 @@ public final class Acquiror implements AutoCloseable {
 		AVector<?> values = RT.ensureVector(result.getValue());
 		if (values == null) throw new BadFormatException("Expected vector in acquisition result");
 
+		Hash firstNullHash = null;
 		for (int i = 0; i < values.count(); i++) {
 			ACell value = values.get(i);
 			if (value == null) {
-				Hash missingHash = (i < requested.length) ? requested[i] : hash;
-				throw new MissingDataException(store, missingHash);
+				if (firstNullHash == null) {
+					firstNullHash = (i < requested.length) ? requested[i] : hash;
+				}
+				continue;
 			}
 			// DATA response cells may themselves be partial. Store the top cell and
 			// let the normal missing-reference loop request its absent branches.
 			Cells.store(value, store);
 		}
+		return firstNullHash;
 	}
 
 	/** True once the worker has terminated, or cancellation prevented it starting. */

--- a/convex-peer/src/main/java/convex/node/NodeServer.java
+++ b/convex-peer/src/main/java/convex/node/NodeServer.java
@@ -1067,17 +1067,46 @@ public class NodeServer<V extends ACell> implements Closeable {
 			if (message.getType() != MessageType.LATTICE_VALUE) {
 				throw new BadFormatException("Missing data acquisition is only valid for LATTICE_VALUE");
 			}
+			// Structural-only checks here -- deliberately NOT calling payload.get(2)
+			// in this guard (see below). A root-sync message's 3rd element is an
+			// "indirect ref" (LatticePropagator.maybePerformRootSync's own
+			// javadoc): a genuinely unresolved branch that dereferences lazily on
+			// first access and can itself throw MissingDataException. That exact
+			// throw, if it happens on THIS guard's own payload.get(2) call, escaped
+			// to the generic catch below (which just gives up -- no acquisition
+			// attempted at all) instead of the MissingDataException-aware recovery
+			// path a few lines down, turning every periodic root sync referencing
+			// not-yet-local data into an immediate, permanent, silently-never-
+			// retried delivery failure -- repeating identically every
+			// ROOT_SYNC_INTERVAL forever, since nothing about the node's state
+			// ever changes to make the SAME lazy access succeed differently next
+			// time.
 			AVector<?> payload = RT.ensureVector(message.getPayload());
-			if (payload == null || payload.count() < 3 || payload.get(2) == null) {
+			if (payload == null || payload.count() < 3) {
 				throw new BadFormatException("Invalid LATTICE_VALUE message format");
 			}
 
 			try {
-				return CompletableFuture.completedFuture(
-					completeLatticeMessage(message, acquisitionStore));
+				Message complete = completeLatticeMessage(message, acquisitionStore);
+				return CompletableFuture.completedFuture(complete);
 			} catch (MissingDataException e) {
-				Hash rootHash = payload.get(2).getHash();
-				return acquireHash(connection, acquisitionStore, rootHash)
+				// Use the hash the exception itself already carries, exactly like
+				// the envelope-decode catch above -- NOT payload.get(2).getHash().
+				// completeLatticeMessage's own payload.get(2) access is what threw
+				// this exception in the first place (a lazy dereference on a
+				// still-incomplete ref, e.g. a root-sync "indirect ref" payload --
+				// see LatticePropagator.maybePerformRootSync's javadoc); calling
+				// payload.get(2) again here hits the exact same still-unresolved
+				// ref and throws again, uncaught, escaping to the generic catch
+				// below with no acquisition ever attempted -- the same underlying
+				// mistake as the guard above (re-deriving a hash via another
+				// risky lazy access instead of using the one the exception
+				// already handed us). The recursive acquireLatticeMessage call
+				// below iterates again after this fetch, so acquiring just this
+				// one missing piece per round (rather than needing the true tree
+				// root in one shot) is sufficient -- it converges the same way
+				// the envelope-decode path above already does.
+				return acquireHash(connection, acquisitionStore, e.getMissingHash())
 					.thenCompose(value -> acquireLatticeMessage(
 						message, acquisitionStore, connection));
 			}

--- a/convex-peer/src/test/java/convex/node/NodeServerTest.java
+++ b/convex-peer/src/test/java/convex/node/NodeServerTest.java
@@ -956,7 +956,16 @@ public class NodeServerTest {
 		try {
 			Blob missingBranch = Blobs.createRandom(400);
 			ASet<ACell> remoteValue = Cells.persist(Sets.of(missingBranch), sourceStore);
-			ingressStore.blockedHash = remoteValue.getHash();
+			// acquireLatticeMessage's MissingDataException handler now acquires
+			// e.getMissingHash() directly (the specific hash the exception already
+			// names) rather than re-deriving the payload's root hash via a second,
+			// separately-risky lazy dereference that could itself throw
+			// MissingDataException, uncaught, permanently failing delivery -- see
+			// NodeServer.acquireLatticeMessage's own comment. remoteValue itself
+			// is small/embeddable and decodes fine; missingBranch (400 bytes,
+			// referenced but not included on the wire) is the actual hash
+			// findMissing reports and Acquiror is asked to fetch.
+			ingressStore.blockedHash = missingBranch.getHash();
 
 			NodeConfig config = NodeConfig.create(Maps.of(
 				NodeConfig.PORT, CVMLong.ZERO,


### PR DESCRIPTION
## Summary

Two independent bugs in the ongoing peer-to-peer lattice sync path that together cause a node to permanently and silently stop receiving updates from a peer, with the only symptom being a recurring `Rejected lattice value after acquisition failure` WARN that never resolves.

### 1. `NodeServer.acquireLatticeMessage` dereferenced `payload.get(2)` outside any missing-data recovery path

`payload.get(2)` (the lattice value element of an inbound `LATTICE_VALUE` message) is a lazy dereference that can itself throw `MissingDataException` -- exactly what happens for `LatticePropagator.maybePerformRootSync`'s wire format, a bare "indirect ref" with no inline data (unlike an ordinary self-contained delta broadcast).

Two call sites accessed it unsafely:
- A guard condition (`payload.get(2) == null`) computed the value purely to null-check it, outside the try/catch that knows how to acquire missing data.
- The `catch (MissingDataException e)` block around `completeLatticeMessage(...)` re-derived the root hash via `payload.get(2).getHash()` again -- assuming a repeat of the exact access that had *just* thrown `MissingDataException` would succeed on retry. It doesn't: a still-incomplete lazy ref throws on every access, not just the first.

Both cases escaped to the generic catch-all, which just gives up -- `Acquiror` was never even invoked, despite the resulting log message implying an acquisition had been attempted and failed.

Once one root sync hits this, the failure repeats identically on every later broadcast that routes through the same unresolved branch, forever, since nothing about local state ever changes to make the same lazy access behave differently next time.

**Fix**: removed the redundant unprotected guard check, and used the exception's own `getMissingHash()` in the catch block instead of re-deriving a hash via another risky lazy access -- mirroring the pattern this method already used correctly for its envelope-level decode a few lines above.

### 2. `Acquiror.acceptResponse` treated a single null response as immediately fatal

A null value in a `DATA_REQUEST` response is an ordinary, expected condition (e.g. the peer hasn't finished persisting the value yet, or the request raced a concurrent write on the peer's side) that typically self-resolves within milliseconds. The previous code threw `MissingDataException` on the first occurrence, with zero retries.

**Fix**: bounded retry (10 attempts, 200ms apart) before giving up.

### Test changes

`NodeServerTest.testCloseWaitsForInboundAcquirorTermination` encoded the old, less-precise acquisition target (the payload's outer root hash) in its own test double's `blockedHash`. Updated to the specific missing leaf hash, matching the corrected, more precise acquisition target.

## How this was found

Diagnosing two peer nodes that silently drifted apart under ordinary live write traffic -- confirmed via a standalone client independently proving the sending node had the data and served it fine to any ordinary connection, while the receiving node could not obtain it via any path, with no error logged anywhere except the recurring WARN above.

## Test plan

- [x] Full `convex-core` suite passes unchanged (2859 tests)
- [x] Full `convex-peer` suite passes, including the updated test (276 tests)
- [x] Verified live against two real peer nodes under sustained concurrent write load (not part of this repo's test suite)
