### PR TITLE
Add LatticePropagator/NodeServer pullPath for selective sub-path replication

### DIFF
--- a/convex-peer/src/main/java/convex/node/LatticePropagator.java
+++ b/convex-peer/src/main/java/convex/node/LatticePropagator.java
@@ -696,4 +696,71 @@ public class LatticePropagator implements Closeable {
 				return acquired;
 			});
 	}
+
+	/**
+	 * Pulls just a sub-path of a peer's lattice value (e.g. one entry of a
+	 * keyed map) instead of its entire root, into this propagator's store.
+	 *
+	 * <p>Sends a LATTICE_QUERY with a real path — the server side
+	 * ({@code NodeServer#processLatticeQuery}) already honours an optional
+	 * path parameter; only the full-root convenience methods above ({@link
+	 * #pull(Convex)}/{@link #pullAll()}) always request the whole root. This
+	 * exists for applications where a peer's lattice root aggregates many
+	 * independent regions (e.g. one entry per named sub-database) and a
+	 * caller only wants — and is only entitled to receive — one of them,
+	 * without transitively pulling everything else that peer happens to
+	 * host too.
+	 *
+	 * <p>Like {@link #pull(Convex)}, this deliberately performs no merge,
+	 * root publication or broadcast — only the caller (typically {@code
+	 * NodeServer}) knows which cursor path the acquired value belongs at,
+	 * and must merge it there itself before any re-propagation.
+	 *
+	 * @param peer Convex connection to the peer node
+	 * @param path Path within the peer's lattice to fetch
+	 * @return CompletableFuture completing with the value at that path (or null if absent there)
+	 */
+	public CompletableFuture<ACell> pullPath(Convex peer, ACell... path) {
+		if (peer == null) {
+			return CompletableFuture.failedFuture(new IllegalArgumentException("Peer cannot be null"));
+		}
+
+		return CompletableFuture.supplyAsync(() -> {
+			try {
+				if (!peer.isConnected()) {
+					throw new RuntimeException("Peer is not connected");
+				}
+
+				CVMLong queryId = CVMLong.create(System.currentTimeMillis());
+				AVector<ACell> pathVector = Vectors.of((Object[]) path);
+				AVector<?> queryPayload = Vectors.create(MessageTag.LATTICE_QUERY, queryId, pathVector);
+				Message queryMessage = Message.create(MessageType.LATTICE_QUERY, queryPayload);
+
+				CompletableFuture<Result> resultFuture = peer.message(queryMessage);
+				Result result = resultFuture.get(10, TimeUnit.SECONDS);
+
+				if (result.isError()) {
+					throw new RuntimeException("Path pull query failed: " + result);
+				}
+
+				ACell receivedValue = result.getValue();
+				if (receivedValue == null) return null;
+
+				ACell acquired;
+				try {
+					acquired = Cells.announce(receivedValue, r -> {}, store);
+				} catch (MissingDataException mde) {
+					Hash rootHash = Hash.get(receivedValue);
+					acquired = peer.acquire(rootHash, store).get(30, TimeUnit.SECONDS);
+				}
+
+				log.debug("Acquired pulled path value from peer: {}", peer.getHostAddress());
+				return acquired;
+
+			} catch (Exception e) {
+				log.warn("Path pull failed from peer: {}", peer.getHostAddress(), e);
+				throw new RuntimeException("Path pull failed from peer", e);
+			}
+		});
+	}
 }

--- a/convex-peer/src/main/java/convex/node/NodeServer.java
+++ b/convex-peer/src/main/java/convex/node/NodeServer.java
@@ -1591,6 +1591,44 @@ public class NodeServer<V extends ACell> implements Closeable {
 	}
 
 	/**
+	 * Pulls just a sub-path of a peer's lattice value (e.g. one entry of a
+	 * keyed map) rather than its entire root, and merges it locally at the
+	 * matching cursor path — for callers that only want (and are only
+	 * entitled to) one region of a peer's lattice, without transitively
+	 * pulling in everything else that peer happens to also host.
+	 *
+	 * <p>Unlike {@link #pull(Convex)}, which merges the acquired value into
+	 * the root via this lattice's own top-level merge, this merges directly
+	 * via {@code cursor.path(path)}'s own sub-lattice semantics — the same
+	 * mechanism {@link #processLatticeValue} uses for incoming broadcasts
+	 * (see {@link #mergeIncoming}). A rejected merge (wrong type, or the
+	 * sub-lattice's own validation) leaves the cursor unchanged, same as an
+	 * untrusted incoming value.
+	 *
+	 * <p>Always checkpoints the root via {@code cursor.sync()} afterward,
+	 * even if the merge was rejected or a no-op — same reasoning as {@link
+	 * #pull(Convex)}: any local writes not yet checkpointed must not be
+	 * skipped just because this particular pull didn't change anything.
+	 *
+	 * @param convex Convex connection to the peer node
+	 * @param path Path within the peer's lattice to pull
+	 * @return CompletableFuture completing with the local value at that path after merge (or null if the peer had nothing there, or the merge was rejected)
+	 */
+	public CompletableFuture<ACell> pullPath(Convex convex, ACell... path) {
+		if (propagators.isEmpty()) {
+			return CompletableFuture.failedFuture(new IllegalStateException("No propagators configured"));
+		}
+		return propagators.get(0).pullPath(convex, path).thenApply(acquired -> {
+			if (acquired != null) {
+				ALatticeCursor<ACell> target = cursor.path(path);
+				mergeIncoming(target, acquired);
+			}
+			cursor.sync();
+			return cursor.path(path).get();
+		});
+	}
+
+	/**
 	 * @deprecated Use {@link #pull(Convex)} instead
 	 */
 	@Deprecated

--- a/convex-peer/src/test/java/convex/node/NodeServerTest.java
+++ b/convex-peer/src/test/java/convex/node/NodeServerTest.java
@@ -60,6 +60,7 @@ import convex.lattice.LatticeContext;
 import convex.lattice.P2PLattice;
 import convex.lattice.cursor.ACursor;
 import convex.lattice.cursor.PathCursor;
+import convex.lattice.generic.KeyedLattice;
 import convex.lattice.generic.MaxLattice;
 import convex.lattice.generic.SetLattice;
 import convex.net.impl.netty.NettyServer;
@@ -511,6 +512,54 @@ public class NodeServerTest {
 			assertEquals(CVMLong.ZERO, result); // Should return initial zero value
 		} finally {
 			peer.close();
+		}
+	}
+
+	/**
+	 * Test that pullPath(Convex, ACell...) pulls only the requested sub-path
+	 * of a peer's lattice value, and does not leak sibling regions the
+	 * caller never asked for — the mechanism behind selective/partial
+	 * replication (e.g. a node replicating just one named sub-database from
+	 * a peer that may host several).
+	 */
+	@Test
+	public void testPullPathDoesNotLeakSiblingRegions() throws Exception {
+		Keyword regionA = Keyword.create("regiona");
+		Keyword regionB = Keyword.create("regionb");
+		KeyedLattice testLattice = KeyedLattice.create(
+			regionA, MaxLattice.create(),
+			regionB, MaxLattice.create());
+
+		NodeServer<Index<Keyword, ACell>> serverA = new NodeServer<>(testLattice, new MemoryStore());
+		NodeServer<Index<Keyword, ACell>> serverB = new NodeServer<>(testLattice, new MemoryStore());
+		try {
+			allowPrimaryInbound(serverA);
+			serverA.launch();
+			serverB.launch();
+
+			// A has data in BOTH regions
+			serverA.getCursor().path(regionA).merge(CVMLong.create(111));
+			serverA.getCursor().path(regionB).merge(CVMLong.create(222));
+			serverA.getCursor().sync();
+
+			ConvexRemote peerA = ConvexRemote.connect(serverA.getHostAddress());
+			try {
+				// B pulls ONLY regionA from A
+				CompletableFuture<ACell> future = serverB.pullPath(peerA, regionA);
+				ACell result = future.get(5, TimeUnit.SECONDS);
+
+				assertEquals(CVMLong.create(111), result);
+				assertEquals(CVMLong.create(111), serverB.getCursor().get(regionA));
+
+				// regionB must NOT have leaked in, even though it lives in
+				// the same lattice value on the peer
+				assertNull(serverB.getCursor().get(regionB));
+			} finally {
+				peerA.close();
+			}
+		} finally {
+			serverA.close();
+			serverB.close();
 		}
 	}
 


### PR DESCRIPTION
## Summary
- `LatticePropagator.pull(Convex)`/`pullAll()` always send an empty-path `LATTICE_QUERY`, requesting a peer's *entire* lattice root — even though the server side (`NodeServer#processLatticeQuery`) already honours an optional path parameter. Applications whose lattice root aggregates several independent regions (e.g. one entry per named sub-database) had no way to fetch just one region without transitively pulling in everything else that peer happens to also host.
- Adds `LatticePropagator.pullPath(Convex, ACell...)`: sends a real `LATTICE_QUERY` path and acquires just that value, performing no merge/broadcast itself (mirrors `pull(Convex)`'s existing division of labour between propagator and caller).
- Adds `NodeServer.pullPath(Convex, ACell...)`: merges the acquired value at the matching cursor sub-path via the same `mergeIncoming` mechanism already used for incoming broadcasts, then checkpoints via `cursor.sync()`.

## Test plan
- [x] `NodeServerTest.testPullPathDoesNotLeakSiblingRegions` — a two-region `KeyedLattice` proves a scoped pull never touches the sibling region even though both live under the same peer root.
- [x] Full `convex-peer`/`convex-core` suite passes unchanged (3136 tests, 0 failures) against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
