### PR TITLE
Fix NPE in AccountKey.equals(AccountKey) on a null argument

### DIFF
--- a/convex-core/src/main/java/convex/core/data/AccountKey.java
+++ b/convex-core/src/main/java/convex/core/data/AccountKey.java
@@ -107,6 +107,7 @@ public class AccountKey extends AArrayBlob {
 
 	public boolean equals(AccountKey o) {
 		if (o == this) return true;
+		if (o == null) return false;
 		return Utils.arrayEquals(o.store, o.offset, this.store, this.offset, LENGTH);
 	}
 

--- a/convex-core/src/test/java/convex/core/data/AccountKeyTest.java
+++ b/convex-core/src/test/java/convex/core/data/AccountKeyTest.java
@@ -1,6 +1,7 @@
 package convex.core.data;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Random;
@@ -50,6 +51,14 @@ public class AccountKeyTest {
 		// AccountKey has comparison equality with Blob
 		assertEquals(0, a.compareTo(b));
 		
-		BlobsTest.doBlobTests(a);			
+		BlobsTest.doBlobTests(a);
+	}
+
+	@Test
+	public void testEqualsNull() {
+		AccountKey a = AccountKey.fromHex(Blob.createRandom(new Random(), AccountKey.LENGTH).toHexString());
+
+		// equals(AccountKey) must not throw on a null argument
+		assertFalse(a.equals((AccountKey) null));
 	}
 }


### PR DESCRIPTION
## Summary
- `AccountKey.equals(AccountKey)` dereferenced `o.store` without checking `o == null` first, so `someKey.equals(null)` threw `NullPointerException` instead of returning `false` as `equals()` implementations are expected to.

Found via a real downstream failure: `LatticeConnectionManager`'s async peer-admission callback compares a possibly-null verified key against the expected `AccountKey` (`peerKey.equals(result)`, where `result` can legitimately be `null` on verification failure) — the NPE here was masking the `SecurityException` that should have surfaced instead.

## Test plan
- [x] Added `AccountKeyTest.testEqualsNull` asserting `a.equals((AccountKey) null)` returns `false` instead of throwing.
- [x] `mvn -pl convex-core test -Dtest=AccountKeyTest` passes.
