### PR TITLE
Fix LatticePropagator.addPeer silently discarding the admission future

### DIFF
--- a/convex-peer/src/main/java/convex/node/LatticePropagator.java
+++ b/convex-peer/src/main/java/convex/node/LatticePropagator.java
@@ -314,11 +314,25 @@ public class LatticePropagator implements Closeable {
 	 * Adds an outbound peer connection with known identity. The peer's store
 	 * is set to this propagator's store, establishing the security boundary.
 	 *
+	 * <p>Blocks (briefly) until the connection is actually admitted, or logs
+	 * a warning and returns on failure/timeout. {@link
+	 * LatticeConnectionManager#addPeer(AccountKey, Convex)} performs an
+	 * async identity-verification handshake before a connection is actually
+	 * admitted -- this method's own signature promises a void, best-effort
+	 * "the peer is now usable" contract, so the returned future must be
+	 * waited on here rather than discarded, or a caller that immediately
+	 * relies on the peer being admitted (e.g. broadcasting to it) would
+	 * silently race the handshake.
+	 *
 	 * @param peerKey AccountKey identifying the remote peer
 	 * @param peer Convex connection to the peer node
 	 */
 	public void addPeer(AccountKey peerKey, Convex peer) {
-		connectionManager.addPeer(peerKey, peer);
+		try {
+			connectionManager.addPeer(peerKey, peer).get(10, TimeUnit.SECONDS);
+		} catch (Exception e) {
+			log.warn("Peer admission did not complete for {}: {}", peerKey, e.getMessage());
+		}
 	}
 
 	/**

--- a/convex-peer/src/test/java/convex/node/LatticePropagatorTest.java
+++ b/convex-peer/src/test/java/convex/node/LatticePropagatorTest.java
@@ -125,6 +125,85 @@ public class LatticePropagatorTest {
 	}
 
 	/**
+	 * Tests that {@code addPeer} actually waits for the async identity
+	 * -verification handshake to complete before returning, when a keypair
+	 * is configured (so the handshake is real, not the {@code kp == null}
+	 * synchronous-admission shortcut). Before this fix, the returned
+	 * CompletableFuture from LatticeConnectionManager.addPeer was discarded,
+	 * so addPeer() could return well before -- or even after a failed --
+	 * admission, with no way for the caller to know.
+	 */
+	@Test
+	public void testAddPeerWaitsForAdmission() throws Exception {
+		AStore storeA = new MemoryStore();
+		AStore storeB = new MemoryStore();
+		NodeServer<?> serverA = new NodeServer<>(lattice, storeA, NodeConfig.port(0));
+		NodeServer<?> serverB = new NodeServer<>(lattice, storeB, NodeConfig.port(0));
+		try {
+			AKeyPair keyA = AKeyPair.generate();
+			AKeyPair keyB = AKeyPair.generate();
+			serverA.setMergeContext(LatticeContext.create(CVMLong.create(System.currentTimeMillis()), keyA));
+			serverB.setMergeContext(LatticeContext.create(CVMLong.create(System.currentTimeMillis()), keyB));
+			serverA.setInboundPropagatorSelector(connection -> serverA.getPropagator());
+			serverB.setInboundPropagatorSelector(connection -> serverB.getPropagator());
+			serverA.launch();
+			serverB.launch();
+
+			AccountKey bKey = keyB.getAccountKey();
+			Convex peerB = ConvexRemote.connect(serverB.getHostAddress());
+
+			// Correct expected identity: admission must have genuinely
+			// completed by the time addPeer() returns, not merely started.
+			serverA.getPropagator().addPeer(bKey, peerB);
+			assertTrue(serverA.getPropagator().getConnectionManager().isConnected(bKey),
+				"addPeer should not return until the peer is actually admitted");
+		} finally {
+			serverA.close();
+			serverB.close();
+			storeA.close();
+			storeB.close();
+		}
+	}
+
+	/**
+	 * Tests that {@code addPeer} does not leave a wrong-identity connection
+	 * looking admitted: the verification handshake must actually run and
+	 * reject a mismatched expected key before addPeer() returns, rather
+	 * than the caller silently getting a connection object that was never
+	 * really verified.
+	 */
+	@Test
+	public void testAddPeerRejectsWrongIdentity() throws Exception {
+		AStore storeA = new MemoryStore();
+		AStore storeB = new MemoryStore();
+		NodeServer<?> serverA = new NodeServer<>(lattice, storeA, NodeConfig.port(0));
+		NodeServer<?> serverB = new NodeServer<>(lattice, storeB, NodeConfig.port(0));
+		try {
+			AKeyPair keyA = AKeyPair.generate();
+			AKeyPair keyB = AKeyPair.generate();
+			serverA.setMergeContext(LatticeContext.create(CVMLong.create(System.currentTimeMillis()), keyA));
+			serverB.setMergeContext(LatticeContext.create(CVMLong.create(System.currentTimeMillis()), keyB));
+			serverA.setInboundPropagatorSelector(connection -> serverA.getPropagator());
+			serverB.setInboundPropagatorSelector(connection -> serverB.getPropagator());
+			serverA.launch();
+			serverB.launch();
+
+			// Wrong expected identity: server B will never sign a challenge
+			// response matching keyA's own account key.
+			Convex peerB = ConvexRemote.connect(serverB.getHostAddress());
+			serverA.getPropagator().addPeer(keyA.getAccountKey(), peerB);
+
+			assertFalse(serverA.getPropagator().getConnectionManager().isConnected(keyA.getAccountKey()),
+				"addPeer must not admit a connection under the wrong expected identity");
+		} finally {
+			serverA.close();
+			serverB.close();
+			storeA.close();
+			storeB.close();
+		}
+	}
+
+	/**
 	 * Tests that automatic propagation broadcasts updates to connected peers.
 	 *
 	 * This test verifies that:


### PR DESCRIPTION
## Summary
- `LatticeConnectionManager.addPeer(AccountKey, Convex)` performs an async identity-verification handshake and returns a `CompletableFuture<Convex>` that completes on admission or fails on a verification mismatch (per its own javadoc).
- `LatticePropagator`'s void-returning `addPeer` wrapper called it but discarded the returned future entirely, so the method could return well before — or even after a failed — admission, with no way for the caller to find out.
- Any caller relying on "`addPeer` returned, so the peer connection is now usable" (e.g. broadcasting to it immediately afterward) was racing the handshake, or silently proceeding after admission was actually rejected.

## Fix
Block on the future with a timeout (matching the 10s convention already used elsewhere in this file for peer round-trips), logging a warning on failure/timeout instead of throwing, to preserve the existing best-effort void contract this method's callers expect.

## Test plan
- [x] Added two tests exercising the real async-verification path (a configured keypair on both sides, as opposed to the `kp == null` synchronous-admission shortcut):
  - `testAddPeerWaitsForAdmission` confirms `addPeer` doesn't return until the peer is genuinely connected.
  - `testAddPeerRejectsWrongIdentity` confirms a wrong-identity peer is never left looking connected.
- [x] Reverting the fix and re-running `testAddPeerWaitsForAdmission` reproduces the original symptom deterministically (confirmed before restoring the fix).
- [x] Full `convex-peer` suite passes with the fix applied.
