### PR TITLE
Fix shared client sequence race in ServerTest

### DIFF
--- a/convex-peer/src/test/java/convex/peer/ServerTest.java
+++ b/convex-peer/src/test/java/convex/peer/ServerTest.java
@@ -498,8 +498,11 @@ public class ServerTest {
 	@Test
 	public void testTransactionPersistedAtIntake() throws Exception {
 		Server server = network.SERVER;
-		synchronized (network.SERVER) {
-			Convex convex = network.CONVEX;
+		Convex convex = network.CONVEX;
+		// Transaction sequencing is owned by the shared client. Hold its monitor
+		// across sequence selection, signing and submission so concurrently running
+		// tests cannot allocate the same sequence between these operations.
+		synchronized (convex) {
 			// Use a non-trivial command to ensure the signed cell has child refs
 			ATransaction tx = Invoke.create(network.HERO, convex.getSequence() + 1,
 					Reader.read("(do (def x 1) (def y 2) (+ x y))"));


### PR DESCRIPTION
## Summary\n- serialise the persistence test's manual sequence selection, signing and submission on the shared Convex client\n- replace the unrelated server monitor, which did not exclude concurrent shared-client transactions\n\nThis removes the race seen in the JDK 25 build for #709, where another parallel test advanced the HERO account between getSequence() and submission.\n\n## Verification\n- ServerTest: 26 tests passed\n- ServerTest stress run: 5 additional passes\n- mvn.cmd -B -T1C test -pl convex-peer -am\n  - convex-core: 3,079 tests, 0 failures\n  - convex-peer: 339 tests, 0 failures, 1 skipped